### PR TITLE
Fix regex to allow commented line replacement in extension ini file

### DIFF
--- a/Abstract/abstract-php-extension.rb
+++ b/Abstract/abstract-php-extension.rb
@@ -168,7 +168,7 @@ EOS
   def write_config_file
     if config_filepath.file?
       inreplace config_filepath do |s|
-        s.gsub!(/^(zend_)?extension=.+$/, "#{extension_type}=\"#{module_path}\"")
+        s.gsub!(/^(;)?(\s+)?(zend_)?extension=.+$/, "\\1\\2#{extension_type}=\"#{module_path}\"")
       end
     elsif config_file
       config_scandir_path.mkpath

--- a/Abstract/abstract-php-extension.rb
+++ b/Abstract/abstract-php-extension.rb
@@ -168,7 +168,7 @@ EOS
   def write_config_file
     if config_filepath.file?
       inreplace config_filepath do |s|
-        s.gsub!(/^(;)?(\s+)?(zend_)?extension=.+$/, "\\1\\2#{extension_type}=\"#{module_path}\"")
+        s.gsub!(/^(;)?(\s*)(zend_)?extension=.+$/, "\\1\\2#{extension_type}=\"#{module_path}\"")
       end
     elsif config_file
       config_scandir_path.mkpath


### PR DESCRIPTION
Upgrading a php extension with a commented extension directive like this one :


```
[pcntl]
;extension="/usr/local/Cellar/php54-pcntl/5.4.35/pcntl.so"
```

throws an error.

```
==> Upgrading php54-pcntl
==> Downloading http://www.php.net/get/php-5.4.35.tar.bz2/from/this/mirror
######################################################################## 100,0%
==> PHP_AUTOCONF="/usr/local/opt/autoconf/bin/autoconf" PHP_AUTOHEADER="/usr/local/opt/autoconf/bin/autoheader" /usr/loc
==> ./configure --prefix=/usr/local/Cellar/php54-pcntl/5.4.35 --with-php-config=/usr/local/Cellar/php54/5.4.35/bin/php-c
==> make
Error: inreplace failed
/usr/local/etc/php/5.4/conf.d/ext-pcntl.ini:
  expected replacement of /^(zend_)?extension=.+$/ with "extension=\"/usr/local/Cellar/php54-pcntl/5.4.35/pcntl.so\""
```
