### PR TITLE
Depend on homebrew/dupes/zlib, not zlib

### DIFF
--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -180,7 +180,7 @@ INFO
       "--enable-mbregex",
       "--enable-bcmath",
       "--enable-calendar",
-      "--with-zlib=#{Formula['zlib'].opt_prefix}",
+      "--with-zlib=#{Formula['homebrew/dupes/zlib'].opt_prefix}",
       "--with-ldap",
       "--with-ldap-sasl=/usr",
       "--with-xmlrpc",
@@ -266,7 +266,7 @@ INFO
 
     if build.with? 'imap'
       args << "--with-imap=#{Formula['imap-uw'].opt_prefix}"
-      
+
       if build.with? 'homebrew-openssl'
         args << "--with-imap-ssl=" + Formula['openssl'].opt_prefix.to_s
       else


### PR DESCRIPTION
Without this change:

  $ brew tap homebrew/dupes
  $ brew install zlib
  $ brew install php56
  ==> Installing php56 from homebrew/homebrew-php
  ==> Downloading https://www.php.net/get/php-5.6.4.tar.bz2/from/this/mirror
  Already downloaded: /Library/Caches/Homebrew/php56-5.6.4
  ==> Patching
  Error: No available formula for dupes/zlib
  Searching formulae...
  Searching taps...

And then it stops.

With this change, it all works.

(I have not tested it with any other PHP formulae.)