### PR TITLE
Allows user to build without LDAP support

### DIFF
--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -64,6 +64,7 @@ class AbstractPhp < Formula
     option 'without-snmp', 'Build without SNMP support'
     option 'without-pcntl', 'Build without Process Control support'
     option 'disable-opcache', 'Build without Opcache extension'
+    option 'without-ldap', 'Build without LDAP support'
   end
 
   # Fixes the pear .lock permissions issue that keeps it from operating correctly.
@@ -182,8 +183,6 @@ INFO
       "--enable-bcmath",
       "--enable-calendar",
       "--with-zlib=#{Formula['zlib'].opt_prefix}",
-      "--with-ldap",
-      "--with-ldap-sasl=/usr",
       "--with-xmlrpc",
       "--with-kerberos=/usr",
       "--with-gd",
@@ -332,6 +331,12 @@ INFO
 
     if build.with? 'phpdbg'
       args << "--enable-phpdbg"
+    end
+    
+    if build.without? 'ldap'
+    else
+      args << "--with-ldap"
+      args << "--with-ldap-sasl=/usr"
     end
 
     return args


### PR DESCRIPTION
Gives the user the ability to build PHP without LDAP support. This is specially important if it is been built with '--with-pdo-oci', since it conflicts with the Oracle Instant Client (OIC) libraries. The OIC has a header named ldap.h which conflicts at compile time with the '--with-ldap-sasl' flag.