### PR TITLE
pecl-jsmin updates for 5.3, 5.4, 5.5 and 5.6

### DIFF
--- a/Formula/php53-jsmin.rb
+++ b/Formula/php53-jsmin.rb
@@ -3,8 +3,8 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 class Php53Jsmin < AbstractPhp53Extension
   init
   homepage 'http://pecl.php.net/package/jsmin'
-  url 'http://pecl.php.net/get/jsmin-0.1.1.tgz'
-  sha1 'b1abfb443ce5df80866fc9350a792f3be814f568'
+  url 'http://pecl.php.net/get/jsmin-1.1.0.tgz'
+  sha1 'e081d7c66a9401b9cd8b0ad585f357a4d7e335ef'
   head 'https://github.com/sqmk/pecl-jsmin.git'
 
   def install

--- a/Formula/php54-jsmin.rb
+++ b/Formula/php54-jsmin.rb
@@ -3,8 +3,8 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 class Php54Jsmin < AbstractPhp54Extension
   init
   homepage 'http://pecl.php.net/package/jsmin'
-  url 'http://pecl.php.net/get/jsmin-0.1.1.tgz'
-  sha1 'b1abfb443ce5df80866fc9350a792f3be814f568'
+  url 'http://pecl.php.net/get/jsmin-1.1.0.tgz'
+  sha1 'e081d7c66a9401b9cd8b0ad585f357a4d7e335ef'
   head 'https://github.com/sqmk/pecl-jsmin.git'
 
   def install

--- a/Formula/php55-jsmin.rb
+++ b/Formula/php55-jsmin.rb
@@ -3,8 +3,8 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 class Php55Jsmin < AbstractPhp55Extension
   init
   homepage 'http://pecl.php.net/package/jsmin'
-  url 'http://pecl.php.net/get/jsmin-0.1.1.tgz'
-  sha1 'b1abfb443ce5df80866fc9350a792f3be814f568'
+  url 'http://pecl.php.net/get/jsmin-1.1.0.tgz'
+  sha1 'e081d7c66a9401b9cd8b0ad585f357a4d7e335ef'
   head 'https://github.com/sqmk/pecl-jsmin.git'
 
   def install

--- a/Formula/php56-jsmin.rb
+++ b/Formula/php56-jsmin.rb
@@ -3,8 +3,8 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 class Php56Jsmin < AbstractPhp56Extension
   init
   homepage 'http://pecl.php.net/package/jsmin'
-  url 'http://pecl.php.net/get/jsmin-0.1.1.tgz'
-  sha1 'b1abfb443ce5df80866fc9350a792f3be814f568'
+  url 'http://pecl.php.net/get/jsmin-1.1.0.tgz'
+  sha1 'e081d7c66a9401b9cd8b0ad585f357a4d7e335ef'
   head 'https://github.com/sqmk/pecl-jsmin.git'
 
   def install


### PR DESCRIPTION
- Update to the latest version of the pecl jsmin extension which is 1.1.0