### PR TITLE
drush: cleanup

### DIFF
--- a/Formula/drush.rb
+++ b/Formula/drush.rb
@@ -1,5 +1,7 @@
+require File.expand_path("../../Requirements/php-meta-requirement", __FILE__)
+
 class Drush < Formula
-  desc "Drush is a command-line shell and scripting interface for Drupal"
+  desc "A command-line shell and scripting interface for Drupal"
   homepage "https://github.com/drush-ops/drush"
   url "https://github.com/drush-ops/drush/archive/7.0.0.tar.gz"
   sha256 "05b7c95902614812978559280a6af86fc7ad3946c11217fe4a14f9df7500d1dc"
@@ -14,11 +16,17 @@ class Drush < Formula
 
   head do
     url "https://github.com/drush-ops/drush.git"
-    depends_on "Homebrew/php/composer" => :build
   end
 
+  depends_on PhpMetaRequirement
+  depends_on "composer" => :build
+  depends_on "php53" if Formula["php53"].linked_keg.exist?
+  depends_on "php54" if Formula["php54"].linked_keg.exist?
+  depends_on "php55" if Formula["php55"].linked_keg.exist?
+  depends_on "php56" if Formula["php56"].linked_keg.exist?
+
   def install
-    system "composer", "install" if build.head?
+    system "composer", "install"
 
     prefix.install_metafiles
     File.delete "drush.bat"


### PR DESCRIPTION
- add PHP dependencies.

- composer is now a build requirement not only for head builds.