### PR TITLE
php5{3..6}-amqp 1.6.0 beta3

### DIFF
--- a/Formula/php53-amqp.rb
+++ b/Formula/php53-amqp.rb
@@ -2,12 +2,13 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 
 class Php53Amqp < AbstractPhp53Extension
   init
-  homepage 'http://pecl.php.net/package/amqp'
-  url 'http://pecl.php.net/get/amqp-1.4.0.tgz'
-  sha1 '7a08ff1cf0368f2f61db360b3402ed8c45444e85'
-  head 'http://svn.php.net/repository/pecl/amqp/trunk/'
+  homepage "http://pecl.php.net/package/amqp"
+  url "http://pecl.php.net/get/amqp-1.6.0beta3.tgz"
+  sha256 "4209dbd96355a0610b42a636621b0b2b34169ef64f8067197a1a5a78a5784ac7"
+  version "1.6.0beta3"
+  head "https://github.com/pdezwart/php-amqp.git"
 
-  depends_on 'rabbitmq-c'
+  depends_on "rabbitmq-c"
 
   def install
     Dir.chdir "amqp-#{version}" unless build.head?

--- a/Formula/php54-amqp.rb
+++ b/Formula/php54-amqp.rb
@@ -2,12 +2,13 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 
 class Php54Amqp < AbstractPhp54Extension
   init
-  homepage 'http://pecl.php.net/package/amqp'
-  url 'http://pecl.php.net/get/amqp-1.4.0.tgz'
-  sha1 '7a08ff1cf0368f2f61db360b3402ed8c45444e85'
-  head 'http://svn.php.net/repository/pecl/amqp/trunk/'
+  homepage "http://pecl.php.net/package/amqp"
+  url "http://pecl.php.net/get/amqp-1.6.0beta3.tgz"
+  sha256 "4209dbd96355a0610b42a636621b0b2b34169ef64f8067197a1a5a78a5784ac7"
+  version "1.6.0beta3"
+  head "https://github.com/pdezwart/php-amqp.git"
 
-  depends_on 'rabbitmq-c'
+  depends_on "rabbitmq-c"
 
   def install
     Dir.chdir "amqp-#{version}" unless build.head?

--- a/Formula/php55-amqp.rb
+++ b/Formula/php55-amqp.rb
@@ -2,12 +2,13 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 
 class Php55Amqp < AbstractPhp55Extension
   init
-  homepage 'http://pecl.php.net/package/amqp'
-  url 'http://pecl.php.net/get/amqp-1.4.0.tgz'
-  sha1 '7a08ff1cf0368f2f61db360b3402ed8c45444e85'
-  head 'http://svn.php.net/repository/pecl/amqp/trunk/'
+  homepage "http://pecl.php.net/package/amqp"
+  url "http://pecl.php.net/get/amqp-1.6.0beta3.tgz"
+  sha256 "4209dbd96355a0610b42a636621b0b2b34169ef64f8067197a1a5a78a5784ac7"
+  version "1.6.0beta3"
+  head "https://github.com/pdezwart/php-amqp.git"
 
-  depends_on 'rabbitmq-c'
+  depends_on "rabbitmq-c"
 
   def install
     Dir.chdir "amqp-#{version}" unless build.head?

--- a/Formula/php56-amqp.rb
+++ b/Formula/php56-amqp.rb
@@ -2,12 +2,13 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 
 class Php56Amqp < AbstractPhp56Extension
   init
-  homepage 'http://pecl.php.net/package/amqp'
-  url 'http://pecl.php.net/get/amqp-1.4.0.tgz'
-  sha1 '7a08ff1cf0368f2f61db360b3402ed8c45444e85'
-  head 'http://svn.php.net/repository/pecl/amqp/trunk/'
+  homepage "http://pecl.php.net/package/amqp"
+  url "http://pecl.php.net/get/amqp-1.6.0beta3.tgz"
+  sha256 "4209dbd96355a0610b42a636621b0b2b34169ef64f8067197a1a5a78a5784ac7"
+  version "1.6.0beta3"
+  head "https://github.com/pdezwart/php-amqp.git"
 
-  depends_on 'rabbitmq-c'
+  depends_on "rabbitmq-c"
 
   def install
     Dir.chdir "amqp-#{version}" unless build.head?


### PR DESCRIPTION
Since the update of `rabbitmq-c` formula, 1.4.0 could not build. 
I tried to see the history of `php-amqp` and didn't find a simple patch to make 1.4.0 compatible.
Homebrew doesn't support versioned depends, so it's removed and replaced with 1.6.0beta3.

If some better solution exists please tell me, thanks.
see homebrew/homebrew#40846