### PR TITLE
Fixed example extension formula so it passes brew audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 
 class Php56Example < AbstractPhp56Extension
   init
+  desc "Concise description of example package"
   homepage "https://pecl.php.net/package/example"
   url "https://pecl.php.net/get/example-1.0.tgz"
   sha1 "SOMEHASHHERE"
@@ -258,7 +259,7 @@ Defining extensions inheriting AbstractPhp5(3456). Extension will provide a `wri
 
 Please note that your formula installation may deviate significantly from the above; caveats should more or less stay the same, as they give explicit instructions to users as to how to ensure the extension is properly installed.
 
-The ordering of formula attributes, such as the `homepage`, `url`, `sha1`, etc. should follow the above order for consistency. The `version` is only included when the URL does not include a version in the filename. `head` installations are not required.
+The ordering of formula attributes, such as the `desc`, `homepage`, `url`, `sha1`, etc. should follow the above order for consistency. The `version` is only included when the URL does not include a version in the filename. `head` installations are not required.
 
 All official PHP extensions should be built for all stable versions of PHP included in `homebrew-php`. These versions are `5.3.29`, `5.4.45`, `5.5.30` and `5.6.14`.
 

--- a/README.md
+++ b/README.md
@@ -230,11 +230,11 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 
 class Php56Example < AbstractPhp56Extension
   init
-  homepage 'https://pecl.php.net/package/example'
-  url 'https://pecl.php.net/get/example-1.0.tgz'
-  sha1 'SOMEHASHHERE'
-  version '1.0'
-  head 'https://svn.php.net/repository/pecl/example/trunk', :using => :svn
+  homepage "https://pecl.php.net/package/example"
+  url "https://pecl.php.net/get/example-1.0.tgz"
+  sha1 "SOMEHASHHERE"
+  version "1.0"
+  head "https://svn.php.net/repository/pecl/example/trunk", :using => :svn
 
   def install
     Dir.chdir "example-#{version}" unless build.head?

--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ The following kinds of brews are allowed:
 
 If you have any concerns as to whether your formula belongs in PHP, just open a pull request with the formula and we'll take it from there.
 
+### Writing formula
+
+See the main [Formula Cookbook](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md) for full details on writing formula. The details below are
+specific to writing PHP formula.
+
+Homebrew PHP formula are by default located under
+`/usr/local/Library/Taps/homebrew/homebrew-php`. If you fork this repository 
+you can work on your changes under that directory (or symlink it into your home
+directory, if that makes things easier) and create a pull request once you are
+ready.
+
+
 ### PHP Extension definitions
 
 PHP Extensions MUST be prefixed with `phpVERSION`. For example, instead of the `Solr` formula for PHP56 in `solr.rb`, we would have `Php56Solr` inside of `php56-solr.rb`. This is to remove any possible conflicts with mainline Homebrew formulae.
@@ -233,7 +245,7 @@ class Php56Example < AbstractPhp56Extension
     system "./configure", "--prefix=#{prefix}", phpconfig
     system "make"
     prefix.install "modules/example.so"
-    write_config_file unless build.include? "without-config-file"
+    write_config_file if build.with? "config-file"
   end
 end
 ```


### PR DESCRIPTION
When working on #2448 the example formula in README.md didn't pass the audit. It also took me a while before I found where the homebrew-php directory was located. This tries to address both.