### PR TITLE
Update Drush formula to 8.0.0

### DIFF
--- a/Formula/drush.rb
+++ b/Formula/drush.rb
@@ -3,8 +3,8 @@ require File.expand_path("../../Requirements/php-meta-requirement", __FILE__)
 class Drush < Formula
   desc "A command-line shell and scripting interface for Drupal"
   homepage "https://github.com/drush-ops/drush"
-  url "https://github.com/drush-ops/drush/archive/7.0.0.tar.gz"
-  sha256 "05b7c95902614812978559280a6af86fc7ad3946c11217fe4a14f9df7500d1dc"
+  url "https://github.com/drush-ops/drush/archive/8.0.0.tar.gz"
+  sha256 "843cf1bff04cf86aff50ebd4ed2cf4b6713270d4e4aa2f60d575de85949121b0"
 
   head do
     url "https://github.com/drush-ops/drush.git"
@@ -12,7 +12,6 @@ class Drush < Formula
 
   depends_on PhpMetaRequirement
   depends_on "composer" => :build
-  depends_on "php53" if Formula["php53"].linked_keg.exist?
   depends_on "php54" if Formula["php54"].linked_keg.exist?
   depends_on "php55" if Formula["php55"].linked_keg.exist?
   depends_on "php56" if Formula["php56"].linked_keg.exist?


### PR DESCRIPTION
Would be nice if we got the new Drush version (8.0.0 - released yesterday to coincide with Drupal 8.0.0 release) by default now.

I have also remove the dependency check for `php53` as drush now supports >= 5.4.