### PR TITLE
added php70-ssh2 extension

### DIFF
--- a/Formula/php70-ssh2.rb
+++ b/Formula/php70-ssh2.rb
@@ -1,0 +1,21 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php70Ssh2 < AbstractPhp70Extension
+  init
+  desc "Provides bindings to the functions of libssh2 which implements the SSH2 protocol."
+  homepage "https://pecl.php.net/package/ssh2"
+  head "https://github.com/php/pecl-networking-ssh2.git", :branch => "master"
+
+  depends_on "libssh2"
+
+  def install
+    safe_phpize
+
+    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "make"
+
+    prefix.install "modules/ssh2.so"
+
+    write_config_file if build.with? "config-file"
+  end
+end

--- a/Formula/php70-ssh2.rb
+++ b/Formula/php70-ssh2.rb
@@ -11,7 +11,9 @@ class Php70Ssh2 < AbstractPhp70Extension
   def install
     safe_phpize
 
-    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "./configure", "--prefix=#{prefix}", 
+                          phpconfig,
+                          "--with-ssh2"
     system "make"
 
     prefix.install "modules/ssh2.so"


### PR DESCRIPTION
I couldn't see --with-ssh2 older php version implementations. But -because of dependent on ssh2- I added.