### PR TITLE
Add php70-apcu-bc

### DIFF
--- a/Formula/php70-apcu-bc.rb
+++ b/Formula/php70-apcu-bc.rb
@@ -1,0 +1,43 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php70ApcuBc < AbstractPhp70Extension
+  init
+  desc "APC User Cache - BC"
+  homepage "https://pecl.php.net/package/apcu_bc"
+  url "https://pecl.php.net/get/apcu_bc-1.0.1.tgz"
+  sha256 "512674d891104d6da91811dbb89d28ab3faa356ee0ab4cbeae9bba9cf3e971cb"
+  head "https://github.com/krakjoe/apcu-bc.git"
+
+  depends_on "php70-apcu"
+
+  def install
+    Dir.chdir "apcu_bc-#{version}" unless build.head?
+
+    ENV.universal_binary if build.universal?
+
+    args = []
+    args << "--enable-apc"
+
+    safe_phpize
+
+    # link in the apcu extension headers
+    mkdir_p "ext/apcu"
+    cp Dir.glob("#{Formula["php70-apcu"].opt_prefix}/include/*.h"), "ext/apcu/"
+
+    system "./configure", "--prefix=#{prefix}",
+                          phpconfig,
+                          *args
+    system "make"
+    prefix.install "modules/apc.so"
+    write_config_file if build.with? "config-file"
+  end
+
+  def extension
+    "apc"
+  end
+
+  # This is changed so that it will be included after apcu
+  def config_filename
+    "ext-bc-" + extension + ".ini"
+  end
+end

--- a/Formula/php70-apcu.rb
+++ b/Formula/php70-apcu.rb
@@ -8,7 +8,6 @@ class Php70Apcu < AbstractPhp70Extension
   sha256 "1582c323d31529c91edc11dcb956ee53660b37e49387d0d609d79d57224a7c30"
   head "https://github.com/krakjoe/apcu.git"
 
-  option "with-apc-bc", "Whether APCu should provide APC full compatibility support"
   depends_on "pcre"
 
   def install
@@ -18,7 +17,6 @@ class Php70Apcu < AbstractPhp70Extension
 
     args = []
     args << "--enable-apcu"
-    args << "--enable-apc-bc" if build.with? "apc-bc"
 
     safe_phpize
 
@@ -26,6 +24,21 @@ class Php70Apcu < AbstractPhp70Extension
                           phpconfig,
                           *args
     system "make"
+    # Keep all the headers that are needed to build php-apc-bc
+    include.install ["php_apc.h",
+      "apc.h",
+      "apc_globals.h",
+      "apc_cache.h",
+      "apc_stack.h",
+      "apc_lock.h",
+      "apc_pool.h",
+      "apc_cache_api.h",
+      "apc_lock_api.h",
+      "apc_sma.h",
+      "apc_pool_api.h",
+      "apc_sma_api.h",
+      "apc_arginfo.h",
+      "apc_iterator.h"]
     prefix.install "modules/apcu.so"
     write_config_file if build.with? "config-file"
   end


### PR DESCRIPTION
Since apcu v5 the backwards compatibility has been moved out into a separate module. This new formula installs this module.

The module includes the php functions `apc_*` (apcu now only provides `apcu_*`)

Also updated apcu such that apcu-bc can be built.