### PR TITLE
Provide composer and composer_install methods

### DIFF
--- a/Formula/boris.rb
+++ b/Formula/boris.rb
@@ -1,6 +1,9 @@
+require File.expand_path("../../language/php", __FILE__)
 require File.expand_path("../../Requirements/php-meta-requirement", __FILE__)
 
 class Boris < Formula
+  include Language::PHP::Composer
+
   desc "Tiny REPL for PHP"
   homepage "https://github.com/borisrepl/boris/"
   url "https://github.com/borisrepl/boris/archive/v1.0.10.tar.gz"
@@ -15,7 +18,6 @@ class Boris < Formula
   end
 
   depends_on PhpMetaRequirement
-  depends_on "composer" => :build
 
   def install
     # ensure the required php modules are installed
@@ -24,7 +26,7 @@ class Boris < Formula
     raise "php must be re-compiled with pcntl support" unless php_modules.include?("pcntl")
     raise "php must be re-compiled with posix support" unless php_modules.include?("posix")
 
-    system "composer", "install"
+    composer_install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/boris"
   end

--- a/Formula/drush.rb
+++ b/Formula/drush.rb
@@ -1,7 +1,10 @@
+require File.expand_path("../../language/php", __FILE__)
 require File.expand_path("../../Requirements/php-meta-requirement", __FILE__)
 
 class Drush < Formula
-  desc "A command-line shell and scripting interface for Drupal"
+  include Language::PHP::Composer
+
+  desc "Command-line shell and scripting interface for Drupal"
   homepage "https://github.com/drush-ops/drush"
   url "https://github.com/drush-ops/drush/archive/8.0.3.tar.gz"
   sha256 "d089a5ea4d3aa56b2a8f62a201c1641143460236c1f1a57090236432bebcb64d"
@@ -17,13 +20,11 @@ class Drush < Formula
   end
 
   depends_on PhpMetaRequirement
-  depends_on "composer" => :build
-  depends_on "php54" if Formula["php54"].linked_keg.exist?
   depends_on "php55" if Formula["php55"].linked_keg.exist?
   depends_on "php56" if Formula["php56"].linked_keg.exist?
 
   def install
-    system "composer", "install"
+    composer_install
 
     prefix.install_metafiles
     File.delete "drush.bat"

--- a/Formula/phan.rb
+++ b/Formula/phan.rb
@@ -1,4 +1,8 @@
+require File.expand_path("../../language/php", __FILE__)
+
 class Phan < Formula
+  include Language::PHP::Composer
+
   desc "Static analyzer for PHP"
   homepage "https://github.com/etsy/phan"
   url "https://github.com/etsy/phan/archive/0.1.tar.gz"
@@ -12,11 +16,10 @@ class Phan < Formula
     sha256 "f538e9d9a64cddd8b2ac8d86daf9fcad5f7620c964c97b3bf6e507da264a3b61" => :mavericks
   end
 
-  depends_on "composer"
   depends_on "php70-ast"
 
   def install
-    system "composer", "install"
+    composer_install
     prefix.install Dir["*"]
     bin.install_symlink prefix/"phan"
   end

--- a/Formula/php-cs-fixer.rb
+++ b/Formula/php-cs-fixer.rb
@@ -1,6 +1,9 @@
+require File.expand_path("../../language/php", __FILE__)
 require File.expand_path("../../Requirements/php-meta-requirement", __FILE__)
 
 class PhpCsFixer < Formula
+  include Language::PHP::Composer
+
   desc "Tries to fix coding standards issues"
   homepage "http://cs.sensiolabs.org"
   url "https://github.com/FriendsOfPHP/PHP-CS-Fixer/archive/v1.11.tar.gz"
@@ -15,10 +18,9 @@ class PhpCsFixer < Formula
   end
 
   depends_on PhpMetaRequirement
-  depends_on "composer"
 
   def install
-    system "composer", "install"
+    composer_install
     prefix.install Dir["*"]
     bin.install_symlink prefix/"php-cs-fixer"
   end

--- a/Formula/php-plantumlwriter.rb
+++ b/Formula/php-plantumlwriter.rb
@@ -1,4 +1,8 @@
+require File.expand_path("../../language/php", __FILE__)
+
 class PhpPlantumlwriter < Formula
+  include Language::PHP::Composer
+
   desc "Create UML diagrams from your PHP source"
   homepage "https://github.com/davidfuhr/php-plantumlwriter"
   url "https://github.com/davidfuhr/php-plantumlwriter/archive/1.6.0.tar.gz"
@@ -12,10 +16,9 @@ class PhpPlantumlwriter < Formula
   end
 
   depends_on "plantuml"
-  depends_on "composer" => :build
 
   def install
-    system "composer", "update"
+    composer_install
 
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/php-plantumlwriter"

--- a/Formula/php53-xhgui.rb
+++ b/Formula/php53-xhgui.rb
@@ -1,14 +1,16 @@
+require File.expand_path("../../language/php", __FILE__)
 require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 
 class Php53Xhgui < AbstractPhp53Extension
+  include Language::PHP::Composer
+
   init
-  desc "A graphical interface for XHProf data built on MongoDB"
+  desc "Graphical interface for XHProf data built on MongoDB"
   homepage "https://github.com/perftools/xhgui"
   url "https://github.com/perftools/xhgui/archive/v0.4.0.tar.gz"
   sha256 "356e6fc46158d827aa6168d55e7de55ea16f539dbabeab5eb5085a9d03f7bb07"
   head "https://github.com/perftools/xhgui.git"
 
-  depends_on "composer"
   depends_on "mongodb"
   depends_on "php53-mcrypt"
   depends_on "php53-mongo"
@@ -18,8 +20,8 @@ class Php53Xhgui < AbstractPhp53Extension
     prefix.install %w[composer.json composer.lock install.php cache config src external webroot]
     (prefix + "cache").chmod 0777
     Dir.chdir prefix
-    system "cp", "config/config.default.php", "config/config.php"
-    system "composer", "install"
+    cp "config/config.default.php", "config/config.php"
+    composer_install
   end
 
   def caveats

--- a/Formula/php54-xhgui.rb
+++ b/Formula/php54-xhgui.rb
@@ -1,14 +1,16 @@
+require File.expand_path("../../language/php", __FILE__)
 require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 
 class Php54Xhgui < AbstractPhp54Extension
+  include Language::PHP::Composer
+
   init
-  desc "A graphical interface for XHProf data built on MongoDB"
+  desc "Graphical interface for XHProf data built on MongoDB"
   homepage "https://github.com/perftools/xhgui"
   url "https://github.com/perftools/xhgui/archive/v0.4.0.tar.gz"
   sha256 "356e6fc46158d827aa6168d55e7de55ea16f539dbabeab5eb5085a9d03f7bb07"
   head "https://github.com/perftools/xhgui.git"
 
-  depends_on "composer"
   depends_on "mongodb"
   depends_on "php54-mcrypt"
   depends_on "php54-mongo"
@@ -18,8 +20,8 @@ class Php54Xhgui < AbstractPhp54Extension
     prefix.install %w[composer.json composer.lock install.php cache config src external webroot]
     (prefix + "cache").chmod 0777
     Dir.chdir prefix
-    system "cp", "config/config.default.php", "config/config.php"
-    system "composer", "install"
+    cp "config/config.default.php", "config/config.php"
+    composer_install
   end
 
   def caveats

--- a/Formula/php55-xhgui.rb
+++ b/Formula/php55-xhgui.rb
@@ -1,14 +1,16 @@
+require File.expand_path("../../language/php", __FILE__)
 require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 
 class Php55Xhgui < AbstractPhp55Extension
+  include Language::PHP::Composer
+
   init
-  desc "A graphical interface for XHProf data built on MongoDB"
+  desc "Graphical interface for XHProf data built on MongoDB"
   homepage "https://github.com/perftools/xhgui"
   url "https://github.com/perftools/xhgui/archive/v0.4.0.tar.gz"
   sha256 "356e6fc46158d827aa6168d55e7de55ea16f539dbabeab5eb5085a9d03f7bb07"
   head "https://github.com/perftools/xhgui.git"
 
-  depends_on "composer"
   depends_on "mongodb"
   depends_on "php55-mcrypt"
   depends_on "php55-mongo"
@@ -18,8 +20,8 @@ class Php55Xhgui < AbstractPhp55Extension
     prefix.install %w[composer.json composer.lock install.php cache config src external webroot]
     (prefix + "cache").chmod 0777
     Dir.chdir prefix
-    system "cp", "config/config.default.php", "config/config.php"
-    system "composer", "install"
+    cp "config/config.default.php", "config/config.php"
+    composer_install
   end
 
   def caveats

--- a/Formula/php56-xhgui.rb
+++ b/Formula/php56-xhgui.rb
@@ -1,14 +1,16 @@
+require File.expand_path("../../language/php", __FILE__)
 require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 
 class Php56Xhgui < AbstractPhp56Extension
+  include Language::PHP::Composer
+
   init
-  desc "A graphical interface for XHProf data built on MongoDB"
+  desc "Graphical interface for XHProf data built on MongoDB"
   homepage "https://github.com/perftools/xhgui"
   url "https://github.com/perftools/xhgui/archive/v0.4.0.tar.gz"
   sha256 "356e6fc46158d827aa6168d55e7de55ea16f539dbabeab5eb5085a9d03f7bb07"
   head "https://github.com/perftools/xhgui.git"
 
-  depends_on "composer"
   depends_on "mongodb"
   depends_on "php56-mcrypt"
   depends_on "php56-mongo"
@@ -18,8 +20,8 @@ class Php56Xhgui < AbstractPhp56Extension
     prefix.install %w[composer.json composer.lock install.php cache config src external webroot]
     (prefix + "cache").chmod 0777
     Dir.chdir prefix
-    system "cp", "config/config.default.php", "config/config.php"
-    system "composer", "install"
+    cp "config/config.default.php", "config/config.php"
+    composer_install
   end
 
   def caveats

--- a/Formula/psysh.rb
+++ b/Formula/psysh.rb
@@ -1,6 +1,9 @@
+require File.expand_path("../../language/php", __FILE__)
 require File.expand_path("../../Requirements/php-meta-requirement", __FILE__)
 
 class Psysh < Formula
+  include Language::PHP::Composer
+
   desc "Runtime developer console, interactive debugger & REPL"
   homepage "https://github.com/bobthecow/psysh"
   url "https://github.com/bobthecow/psysh/archive/v0.5.2.tar.gz"
@@ -15,10 +18,9 @@ class Psysh < Formula
   end
 
   depends_on PhpMetaRequirement
-  depends_on "composer" => :build
 
   def install
-    system "composer", "install", "--no-dev"
+    composer_install "--no-dev"
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/psysh"
   end

--- a/Formula/terminus.rb
+++ b/Formula/terminus.rb
@@ -1,6 +1,9 @@
+require File.expand_path("../../language/php", __FILE__)
 require File.expand_path("../../Requirements/php-meta-requirement", __FILE__)
 
 class Terminus < Formula
+  include Language::PHP::Composer
+
   desc "Command-line interface for the Pantheon Platform"
   homepage "https://github.com/pantheon-systems/cli"
   url "https://github.com/pantheon-systems/cli/archive/0.10.3.tar.gz"
@@ -15,10 +18,9 @@ class Terminus < Formula
   end
 
   depends_on PhpMetaRequirement
-  depends_on "composer" => :build
 
   def install
-    system "composer", "install"
+    composer_install
 
     rm "bin/terminus.bat"
     rm "bin/behat"

--- a/Formula/wp-cli.rb
+++ b/Formula/wp-cli.rb
@@ -1,5 +1,9 @@
+require File.expand_path("../../language/php", __FILE__)
+
 class WpCli < Formula
-  desc "A set of command-line tools for managing WordPress installations."
+  include Language::PHP::Composer
+
+  desc "Command-line tools for managing WordPress installations."
   homepage "http://wp-cli.org/"
   url "https://github.com/wp-cli/wp-cli/archive/v0.22.0.tar.gz"
   sha256 "a51c8cea5e4bd8a210ed397b0639595515a6cc14e8a06c8e2138445d81bcbc86"
@@ -15,10 +19,8 @@ class WpCli < Formula
   option "without-bash-completion", "Don't install bash completion"
   option "without-package-index", "Don't add package index repository (http://wp-cli.org/package-index)"
 
-  depends_on "composer" => :build
-
   def install
-    system "composer", "install"
+    composer_install
 
     rm "bin/wp.bat"
     prefix.install Dir["*"]
@@ -28,7 +30,7 @@ class WpCli < Formula
     end
 
     if build.with? "package-index"
-      system "composer", "config", "--file=#{prefix}/composer.json", "repositories.wp-cli", "composer", "http://wp-cli.org/package-index/"
+      composer "config", "--file=#{prefix}/composer.json", "repositories.wp-cli", "composer", "http://wp-cli.org/package-index/"
     end
   end
 

--- a/language/php.rb
+++ b/language/php.rb
@@ -1,0 +1,37 @@
+require File.expand_path("../../Requirements/php-meta-requirement", __FILE__)
+
+module Language
+  module PHP
+    module Composer
+      def self.included(base)
+        base.depends_on "composer" => :build
+      end
+
+      def composer(*args)
+        # No interaction is possible during brew commands
+        args.unshift("--no-interaction")
+
+        if ARGV.verbose?
+          args.unshift("--verbose")
+        end
+
+        system "composer", *args
+      end
+
+      def composer_config_github_api_token
+        # Configure the Github API token if we have one and no token is configured yet
+        if ENV["HOMEBREW_GITHUB_API_TOKEN"] and !(quiet_system "composer", "--no-interaction", "config", "github-oauth.github.com")
+          # We don't want to expose the token in the terminal
+          ohai "composer config github-oauth.github.com <HOMEBREW_GITHUB_API_TOKEN>".strip
+          Homebrew._system "composer", "--no-interaction", "config", "github-oauth.github.com", ENV["HOMEBREW_GITHUB_API_TOKEN"]
+        end
+      end
+
+      def composer_install(*args)
+        # Use a token for install to get around API rate limit
+        composer_config_github_api_token
+        composer "install", *args
+      end
+    end
+  end
+end


### PR DESCRIPTION
Yesterday I was installing the [phan](https://github.com/Homebrew/homebrew-php/blob/master/Formula/phan.rb) formula and I ran into a couble of problems (not really related to phan itself).

The formula does a `composer install` during installation (like a dozen others). But it ended up failing because it hit the Github API rate limit. Although I have a `$HOMEBREW_GITHUB_API_TOKEN` token set in my environment it is only used by brews own Github operation and not exposed to Composer.

An since Composer will default to asking the user at stdin for a token and brew doesn't display stdin from the command I ended up with an install operation that just kept hanging.

The lesson would be to always run Composer with the `--no-interaction` flag and ensure that the `$HOMEBREW_GITHUB_API_TOKEN` value will be used for the `composer install` command.

Since 12 formulas currently do a composer install it makes sense to fix/ensure this in a general fashion instead of every formula having to ensure it by itself.

Inspired by how Homebrew defines a [`cabal_install` method for Haskell](https://github.com/Homebrew/homebrew/blob/master/Library/Homebrew/language/haskell.rb) (see its usage i.e. in [arx](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/arx.rb)) I have implemented `composer` and `composer_install` methods for ensuring `--no-interaction` and the Github API token.

I have also changed the 12 formulas doing `composer install` to uses this (a few of them have gotten some minor stylistic changes as well so they pass `brew audit --strict`.