### PR TITLE
Removes freetype header path patch for php53

### DIFF
--- a/Formula/php53.rb
+++ b/Formula/php53.rb
@@ -51,7 +51,7 @@ class Php53 < AbstractPhp
 
   # Previous Bison and 10.9+ patches, and multi-SAPIs patch (https://pecl.php.net/~jani/patches/multi-sapi.patch) applied
   patch do
-    url "https://gist.githubusercontent.com/ablyler/c0264742cc1cca84b708/raw/a5c5c5c689acc003b5db6a9703b4f7d1d586a593/multi-sapi-5.3.29-homebrew.patch"
-    sha256 "e21f593ef290851d057ae07b0e513ef188304140912e18a0f28355b801dc2b40"
+    url "https://gist.githubusercontent.com/javian/bfcbd5bc5874ee9c539fb3d642cdce3e/raw/bf079cc68ec76290f02f57981ae85b20a06dd428/multi-sapi-5.3.29-homebrew.patch"
+    sha256 "3c3157bc5c4346108a398798b84dbbaa13409c43d3996bea2ddacb3277e0cee2"
   end
 end


### PR DESCRIPTION
The patched patch no longer patches the freetype header path since the location in the freetype package has changed. Fixes #3014 so that php53 can compile.