### PR TITLE
revisions for icu4c

### DIFF
--- a/Formula/php53-intl.rb
+++ b/Formula/php53-intl.rb
@@ -7,6 +7,7 @@ class Php53Intl < AbstractPhp53Extension
   url PHP_SRC_TARBALL
   sha256 PHP_CHECKSUM[:sha256]
   version PHP_VERSION
+  revision 1
 
   bottle do
     revision 1

--- a/Formula/php53-yaz.rb
+++ b/Formula/php53-yaz.rb
@@ -6,6 +6,7 @@ class Php53Yaz < AbstractPhp53Extension
   homepage "http://www.indexdata.com/phpyaz"
   url "https://pecl.php.net/get/yaz-1.1.9.tgz"
   sha256 "9dd4da2fd6042b37a1811972134f852c94a6f6b85ca4ec5ed5d766eb27a6c401"
+  revision 1
 
   bottle do
     sha256 "5d0e3691ff90cae813057cf7330bd68d9f8cd948b5df5c0e1a4ece15e42cdac8" => :el_capitan

--- a/Formula/php54-intl.rb
+++ b/Formula/php54-intl.rb
@@ -7,6 +7,7 @@ class Php54Intl < AbstractPhp54Extension
   url PHP_SRC_TARBALL
   sha256 PHP_CHECKSUM[:sha256]
   version PHP_VERSION
+  revision 1
 
   bottle do
     revision 2

--- a/Formula/php54-yaz.rb
+++ b/Formula/php54-yaz.rb
@@ -6,6 +6,7 @@ class Php54Yaz < AbstractPhp54Extension
   homepage "http://www.indexdata.com/phpyaz"
   url "https://pecl.php.net/get/yaz-1.1.9.tgz"
   sha256 "9dd4da2fd6042b37a1811972134f852c94a6f6b85ca4ec5ed5d766eb27a6c401"
+  revision 1
 
   bottle do
     sha256 "829b0b0e1ff54e92faf67b28646f63c199579fe8021051a925eeb9637aec5b6d" => :el_capitan

--- a/Formula/php55-intl.rb
+++ b/Formula/php55-intl.rb
@@ -7,6 +7,7 @@ class Php55Intl < AbstractPhp55Extension
   url PHP_SRC_TARBALL
   sha256 PHP_CHECKSUM[:sha256]
   version PHP_VERSION
+  revision 1
 
   bottle do
     sha256 "7a0d3ecedf27ab80fd5b5f62b7de6bb9b8397adb76f0ae173b7af3fe492759d9" => :el_capitan

--- a/Formula/php55-yaz.rb
+++ b/Formula/php55-yaz.rb
@@ -6,6 +6,7 @@ class Php55Yaz < AbstractPhp55Extension
   homepage "http://www.indexdata.com/phpyaz"
   url "https://pecl.php.net/get/yaz-1.1.9.tgz"
   sha256 "9dd4da2fd6042b37a1811972134f852c94a6f6b85ca4ec5ed5d766eb27a6c401"
+  revision 1
 
   bottle do
     sha256 "6836b5b5b4098a8bc991e608152a12bb426a4a958dfeada54b451e669511f6bb" => :el_capitan

--- a/Formula/php56-intl.rb
+++ b/Formula/php56-intl.rb
@@ -7,6 +7,7 @@ class Php56Intl < AbstractPhp56Extension
   url PHP_SRC_TARBALL
   sha256 PHP_CHECKSUM[:sha256]
   version PHP_VERSION
+  revision 1
 
   bottle do
     sha256 "08f3b966d49bc039e674127a778bb0c8f05082c3d8e773c76954af289347a8e5" => :el_capitan

--- a/Formula/php56-yaz.rb
+++ b/Formula/php56-yaz.rb
@@ -6,6 +6,7 @@ class Php56Yaz < AbstractPhp56Extension
   homepage "http://www.indexdata.com/phpyaz"
   url "https://pecl.php.net/get/yaz-1.1.9.tgz"
   sha256 "9dd4da2fd6042b37a1811972134f852c94a6f6b85ca4ec5ed5d766eb27a6c401"
+  revision 1
 
   bottle do
     sha256 "5281761c3f003f948897282b81c123c69847a940c5f7c371b915ac6cc93ef527" => :el_capitan

--- a/Formula/php70-intl.rb
+++ b/Formula/php70-intl.rb
@@ -13,6 +13,7 @@ class Php70Intl < AbstractPhp70Extension
   url PHP_SRC_TARBALL
   sha256 PHP_CHECKSUM[:sha256]
   version PHP_VERSION
+  revision 1
 
   depends_on "icu4c"
 


### PR DESCRIPTION
icu4c got a version bump (see Homebrew/homebrew-core#183).

This PR includes revision bumps for php packages that depend on ICU.