### PR TITLE
brew php-debug-info command to support issue creation

### DIFF
--- a/cmd/brew-php-debug-info.rb
+++ b/cmd/brew-php-debug-info.rb
@@ -1,0 +1,46 @@
+#:  * `php-debug-info`:
+#:     Prints debug info for issue submission for PHP tap
+
+output = []
+
+system_php_output = IO.popen("env php -r 'echo phpversion();'", :err=>[:child, :out]) 
+system_php = system_php_output.read
+system_php_output.close
+
+#system_php = `env php -r 'echo phpversion();'`
+
+
+system_gcc_output = IO.popen("env gcc -v", :err=>[:child, :out]) 
+system_gcc = system_gcc_output.read
+system_gcc_output.close
+
+system_php_v_output = IO.popen("env php -v", :err=>[:child, :out]) 
+system_php_v = system_php_v_output.read
+system_php_v_output.close
+
+output << <<-EOS.undent
+## Description
+
+_Please describe the problem you are experiencing in this section_
+
+## Context and Logs
+
+Parameter | Value
+--------- | ------------------
+**OS X Version:**       | #{MacOS.full_version}
+**Homebrew Version:**   | #{HOMEBREW_VERSION}
+**Xcode Version:**      | #{MacOS::Xcode.version }
+**PHP Version in use:** | #{system_php}
+
+**Output of gcc -v:**
+#{system_gcc.chomp}
+
+**Output of php -v:**
+#{system_php_v.chomp}
+
+**Build logs:** _Link to public gist created with `brew gist-logs my-formula`_
+
+EOS
+
+output.join "\n"
+puts output

--- a/cmd/brew-php-debug-info.rb
+++ b/cmd/brew-php-debug-info.rb
@@ -7,9 +7,6 @@ system_php_output = IO.popen("env php -r 'echo phpversion();'", :err=>[:child, :
 system_php = system_php_output.read
 system_php_output.close
 
-#system_php = `env php -r 'echo phpversion();'`
-
-
 system_gcc_output = IO.popen("env gcc -v", :err=>[:child, :out]) 
 system_gcc = system_gcc_output.read
 system_gcc_output.close


### PR DESCRIPTION
I thought I would build on the idea of generating the issue template locally and populate the different fields. It is quick and dirty but shows the potential. If you feel this is useful I'll brush it up a bit or if you have additional ideas on what to include since I based this on the current template then we could include this as well. The gist-log command could be run but not everyone might have tokens configured to support it so I assumed that it might just be more hassle to include it.

Currently it doesn't handle unloadable modules very well and prints additional data which skews the template like this.

```
➜  Homebrew git:(master) ✗ brew php-debug-info
## Description

_Please describe your problem in this section_

## Context and Logs

Parameter | Value
--------- | ------------------
**OS X Version:**       | 10.11.4
**Homebrew Version:**   | 0.9.9
**Xcode Version:**      | 7.3
**PHP Version in use:** | PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/local/Cellar/php56/5.6.20/lib/php/extensions/no-debug-zts-20131226/curl.so' - dlopen(/usr/local/Cellar/php56/5.6.20/lib/php/extensions/no-debug-zts-20131226/curl.so, 9): image not found in Unknown on line 0
PHP Warning:  PHP Startup: mcrypt: Unable to initialize module
Module compiled with build ID=API20131226,NTS
PHP    compiled with build ID=API20131226,TS,debug
These options need to match
in Unknown on line 0
PHP Warning:  PHP Startup: pthreads: Unable to initialize module
Module compiled with build ID=API20131226,TS
PHP    compiled with build ID=API20131226,TS,debug
These options need to match
in Unknown on line 0
```

and despite the error redirection it still takes the addtional output and sticks it in to the variables. A proper run without errors should look like this.

```
➜  Homebrew git:(master) ✗ brew help php-debug-info
## Description

_Please describe the problem you are experiencing in this section_

## Context and Logs

Parameter | Value
--------- | ------------------
**OS X Version:**       | 10.11.4
**Homebrew Version:**   | 0.9.9
**Xcode Version:**      | 7.3
**PHP Version in use:** | 7.0.5

**Output of gcc -v:**
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 7.3.0 (clang-703.0.29)
Target: x86_64-apple-darwin15.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

**Output of php -v:**
PHP 7.0.5 (cli) (built: Apr 12 2016 00:20:02) ( NTS )
Copyright (c) 1997-2016 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2016 Zend Technologies

**Build logs:** _Link to public gist created with `brew gist-logs my-formula`_

➜
```
