### PR TITLE
Add head formula for php70-uploadprogress

### DIFF
--- a/Formula/php70-uploadprogress.rb
+++ b/Formula/php70-uploadprogress.rb
@@ -1,0 +1,26 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php70Uploadprogress < AbstractPhp70Extension
+  init
+  desc "Extension to track progress of a file upload."
+  homepage "https://pecl.php.net/package/uploadprogress"
+  url "https://git.php.net/repository/pecl/php/uploadprogress.git",
+    :revision => "95d8a0fd4554e10c215d3ab301e901bd8f99c5d9"
+  version "95d8a0f"
+  head "https://git.php.net/repository/pecl/php/uploadprogress.git"
+
+  depends_on "pcre"
+
+  def install
+    # Dir.chdir "uploadprogress-#{version}" unless build.head?
+
+    ENV.universal_binary if build.universal?
+
+    safe_phpize
+    system "./configure", "--prefix=#{prefix}",
+                            phpconfig
+    system "make"
+    prefix.install "modules/uploadprogress.so"
+    write_config_file if build.with? "config-file"
+  end
+end


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

There isn't a release yet, but the uploadprogress repository has a couple commits for php7 compatibility.

I was unable to verify that the extension actually worked on a Drupal install, but it installed without error and appears in `phpinfo()`
