### PR TITLE
Revert "Modify composer phar wrapper to disable xdebug"

### DIFF
--- a/Formula/composer.rb
+++ b/Formula/composer.rb
@@ -6,22 +6,8 @@ class Composer < AbstractPhpPhar
   homepage "http://getcomposer.org"
   url "https://getcomposer.org/download/1.1.1/composer.phar"
   sha256 "7f26efee06de5a1a061b6b1e330f5acc9ee69976d1551118c45b21f358cbc332"
-  revision 1
+  revision 2
   head "https://getcomposer.org/composer.phar"
-
-  def phar_wrapper
-    <<-EOS.undent
-      #!/usr/bin/env bash
-
-      TEMP_PATH="$( mktemp -t php-no-debug )"
-      FILES="$( /usr/bin/env php -r 'echo php_ini_loaded_file() . "\n" . str_replace(",","", php_ini_scanned_files());' )"
-      cat $FILES | sed '/xdebug/d' > "$TEMP_PATH"
-
-      /usr/bin/env php -n -c "$TEMP_PATH" -d detect_unicode=Off #{libexec}/#{@real_phar_file} "$@"
-
-      rm -f "$TEMP_PATH"
-    EOS
-  end
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

This reverts commit 03e3b7293034fa74f524d865d649702e886f0d17.
This caused problems for existing workflows and changed the
default behaviour of composer. Awaiting a more non-intrusive
solution this commit is reverted.

Fixes #3230 