### PR TITLE
Prevent PHP 7.1 as beeing set as the default php formula

### DIFF
--- a/Requirements/php-meta-requirement.rb
+++ b/Requirements/php-meta-requirement.rb
@@ -2,7 +2,7 @@ require File.join(File.dirname(__FILE__), 'homebrew-php-requirement')
 
 class PhpMetaRequirement < HomebrewPhpRequirement
   if $supported_php_versions.nil?
-    $supported_php_versions = %w{php53 php54 php55 php56 php70 php71}
+    $supported_php_versions = %w{php53 php54 php55 php56 php71 php70}
   end
 
   if Formula["php53"].linked_keg.exist? && $supported_php_versions.include?('php53')


### PR DESCRIPTION
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

