### PR TITLE
PHP Code Sniffer updated to 2.6.2

### DIFF
--- a/Formula/php-code-sniffer.rb
+++ b/Formula/php-code-sniffer.rb
@@ -3,8 +3,8 @@ require File.expand_path("../../Requirements/php-meta-requirement", __FILE__)
 class PhpCodeSniffer < Formula
   desc "Check coding standards in PHP, JavaScript and CSS"
   homepage "http://pear.php.net/package/PHP_CodeSniffer"
-  url "http://download.pear.php.net/package/PHP_CodeSniffer-2.6.1.tgz"
-  sha256 "49be3e6462d1a572afd4d941e0b75ff5ba66e1050ec0428f9c9f107a208506d6"
+  url "http://download.pear.php.net/package/PHP_CodeSniffer-2.6.2.tgz"
+  sha256 "f5c71941e254742130e22cd5ef48d3b06b486efbd1b3dbc7f2fa77acdeac650d"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

PHP CodeSniffer is updated to v2.6.2