### PR TITLE
Update phpdocumentor to version 2.9.0

### DIFF
--- a/Formula/phpdocumentor.rb
+++ b/Formula/phpdocumentor.rb
@@ -4,9 +4,9 @@ class Phpdocumentor < AbstractPhpPhar
   init
   desc "Documentation Generator for PHP"
   homepage "http://www.phpdoc.org"
-  url "https://github.com/phpDocumentor/phpDocumentor2/releases/download/v2.8.5/phpDocumentor.phar"
-  version "2.8.5"
-  sha256 "7613a3d6ffc182595b7423bc2373cd215cac269135f4b0f973e5c1b617b565b7"
+  url "https://github.com/phpDocumentor/phpDocumentor2/releases/download/v2.9.0/phpDocumentor.phar"
+  version "2.9.0"
+  sha256 "c7dadb6af3feefd4b000c19f96488d3c46c74187701d6577c1d89953cb479181"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----
Updated version (2.9.0) of phpdocumentor enables it to be used with PHP 7.0