### PR TITLE
Prevent php from hardcoding superenv SED path

### DIFF
--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -176,6 +176,9 @@ INFO
   end
 
   def install_args
+    # prevent php from hardcoding sed path from superenv
+    ENV["SED"] = "sed" 
+
     args = [
       "--prefix=#{prefix}",
       "--localstatedir=#{var}",


### PR DESCRIPTION
There have been several issues related to this due to homebrew switching the directory structure without migrating old installs. This will eventually happen but it would be better practice to not be reliant on the superenv shim and work directly towards the bundled sed.

