### PR TITLE
Fix apxs detection for --with-apache option

### DIFF
--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -153,7 +153,7 @@ INFO
   end
 
   def apache_apxs
-    if build.with?('homebrew-apxs') || MacOS.version == :sierra
+    if build.with?('homebrew-apxs') || build.with?('apache') || build.with?('apache22')
       ['sbin', 'bin'].each do |dir|
         if File.exist?(location = "#{HOMEBREW_PREFIX}/#{dir}/apxs")
           return location


### PR DESCRIPTION
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

This needs to be cleaned up more but should fix the apxs detection issue in the meantime.