### PR TITLE
use --disable-memcached-sasl instead of --enable-memcached-sasl

### DIFF
--- a/Formula/php53-memcached.rb
+++ b/Formula/php53-memcached.rb
@@ -32,7 +32,7 @@ class Php53Memcached < AbstractPhp53Extension
     args = []
     args << "--with-libmemcached-dir=#{Formula["libmemcached"].opt_prefix}"
     args << "--enable-memcached-igbinary"
-    args << "--enable-memcached-sasl" if build.with? "sasl"
+    args << "--disable-memcached-sasl" if build.without? "sasl"
 
     safe_phpize
 

--- a/Formula/php54-memcached.rb
+++ b/Formula/php54-memcached.rb
@@ -32,7 +32,7 @@ class Php54Memcached < AbstractPhp54Extension
     args = []
     args << "--with-libmemcached-dir=#{Formula["libmemcached"].opt_prefix}"
     args << "--enable-memcached-igbinary"
-    args << "--enable-memcached-sasl" if build.with? "sasl"
+    args << "--disable-memcached-sasl" if build.without? "sasl"
 
     safe_phpize
 

--- a/Formula/php55-memcached.rb
+++ b/Formula/php55-memcached.rb
@@ -32,7 +32,7 @@ class Php55Memcached < AbstractPhp55Extension
     args = []
     args << "--with-libmemcached-dir=#{Formula["libmemcached"].opt_prefix}"
     args << "--enable-memcached-igbinary"
-    args << "--enable-memcached-sasl" if build.with? "sasl"
+    args << "--disable-memcached-sasl" if build.without? "sasl"
 
     safe_phpize
 

--- a/Formula/php56-memcached.rb
+++ b/Formula/php56-memcached.rb
@@ -32,7 +32,7 @@ class Php56Memcached < AbstractPhp56Extension
     args = []
     args << "--with-libmemcached-dir=#{Formula["libmemcached"].opt_prefix}"
     args << "--enable-memcached-igbinary"
-    args << "--enable-memcached-sasl" if build.with? "sasl"
+    args << "--disable-memcached-sasl" if build.without? "sasl"
 
     safe_phpize
 

--- a/Formula/php70-memcached.rb
+++ b/Formula/php70-memcached.rb
@@ -25,7 +25,7 @@ class Php70Memcached < AbstractPhp70Extension
     args = []
     args << "--with-libmemcached-dir=#{Formula["libmemcached"].opt_prefix}"
     args << "--enable-memcached-igbinary"
-    args << "--enable-memcached-sasl" if build.with? "sasl"
+    args << "--disable-memcached-sasl" if build.without? "sasl"
 
     safe_phpize
 


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

According to `./configure --help` of ext-memcached@2.2.0, there is no `--enable-memcached-sasl` but `--disable-memcached-sasl`