### PR TITLE
Update php56-ioncubeloader.rb

### DIFF
--- a/Formula/php56-ioncubeloader.rb
+++ b/Formula/php56-ioncubeloader.rb
@@ -6,12 +6,12 @@ class Php56Ioncubeloader < AbstractPhp56Extension
   homepage "http://www.ioncube.com/loaders.php"
   if MacOS.prefer_64_bit?
     url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-    sha256 "e3649def6e14f8d6aad08326e6579a7b7e660e3eca65c240755f759b3920efa8"
+    sha256 "808b6bf93662f96579ad4ce9b6d4c999d98e6e543f9630b45a2b31c2907127d5"
   else
     url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86.tar.gz"
-    sha256 "96a0e211971352acb843718565c371938881da7d77dd8bca7519466f06dfdda2"
+    sha256 "0586f13ac48e383309b7d56bb5ae7b4ee9872d012b6b9b78b273f1de780c4123"
   end
-  version "6.0.5"
+  version "6.0.6"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

updated ionCube loaders to latest released version 6.0.6 per ionCube site