### PR TITLE
add formula for php-vips-ext

### DIFF
--- a/Formula/php70-vips-ext.rb
+++ b/Formula/php70-vips-ext.rb
@@ -1,0 +1,30 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php70VipsExt < AbstractPhp70Extension
+  init
+  desc "Native part of php-vips"
+  homepage "https://github.com/jcupitt/php-vips-ext"
+  url "https://github.com/jcupitt/php-vips-ext/archive/v0.1.2.tar.gz"
+  sha256 "72d7e821d2899729de0f9ff616350721d12371e08016f069f5b5836837f5e859"
+  head "https://github.com/jcupitt/php-vips-ext.git"
+
+  depends_on "pkg-config" => :build
+
+  depends_on "vips"
+
+  def install
+    ENV.universal_binary if build.universal?
+
+    args = []
+    args << "--with-vips"
+
+    safe_phpize
+
+    system "./configure", "--prefix=#{prefix}",
+                          phpconfig,
+                          *args
+    system "make"
+    prefix.install "modules/vips.so"
+    write_config_file if build.with? "config-file"
+  end
+end

--- a/Formula/php70-vips.rb
+++ b/Formula/php70-vips.rb
@@ -3,26 +3,21 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 class Php70Vips < AbstractPhp70Extension
   init
   desc "Native part of php-vips"
-  homepage "https://github.com/jcupitt/php-vips-ext"
-  url "https://github.com/jcupitt/php-vips-ext/archive/v1.0.2.tar.gz"
-  sha256 "52d005ecc18930c97e1927c6a8b5d9390614946520b895fea42a5b790e34c4df"
+  homepage "https://pecl.php.net/package/vips"
+  url "https://pecl.php.net/get/vips-1.0.7.tgz"
+  sha256 "ddc3f396237af05ee4ef5f207b004c7b387b28736d9c1878dd24475a807c5337"
   head "https://github.com/jcupitt/php-vips-ext.git"
 
   depends_on "pkg-config" => :build
-
-  depends_on "homebrew/science/vips"
+  depends_on "vips"
 
   def install
-    ENV.universal_binary if build.universal?
+    Dir.chdir "vips-#{version}" unless build.head?
 
     args = []
     args << "--with-vips"
-
     safe_phpize
-
-    system "./configure", "--prefix=#{prefix}",
-                          phpconfig,
-                          *args
+    system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
     prefix.install "modules/vips.so"
     write_config_file if build.with? "config-file"

--- a/Formula/php70-vips.rb
+++ b/Formula/php70-vips.rb
@@ -1,16 +1,16 @@
 require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 
-class Php70VipsExt < AbstractPhp70Extension
+class Php70Vips < AbstractPhp70Extension
   init
   desc "Native part of php-vips"
   homepage "https://github.com/jcupitt/php-vips-ext"
-  url "https://github.com/jcupitt/php-vips-ext/archive/v0.1.2.tar.gz"
-  sha256 "72d7e821d2899729de0f9ff616350721d12371e08016f069f5b5836837f5e859"
+  url "https://github.com/jcupitt/php-vips-ext/archive/v0.1.3.tar.gz"
+  sha256 "dfd11b502e00ce7e406cf8f82fe48fe9612df1a818d3dc6cb4c8561092699ae8"
   head "https://github.com/jcupitt/php-vips-ext.git"
 
   depends_on "pkg-config" => :build
 
-  depends_on "vips"
+  depends_on "homebrew/science/vips"
 
   def install
     ENV.universal_binary if build.universal?

--- a/Formula/php70-vips.rb
+++ b/Formula/php70-vips.rb
@@ -4,8 +4,8 @@ class Php70Vips < AbstractPhp70Extension
   init
   desc "Native part of php-vips"
   homepage "https://github.com/jcupitt/php-vips-ext"
-  url "https://github.com/jcupitt/php-vips-ext/archive/v0.1.3.tar.gz"
-  sha256 "dfd11b502e00ce7e406cf8f82fe48fe9612df1a818d3dc6cb4c8561092699ae8"
+  url "https://github.com/jcupitt/php-vips-ext/archive/v1.0.2.tar.gz"
+  sha256 "52d005ecc18930c97e1927c6a8b5d9390614946520b895fea42a5b790e34c4df"
   head "https://github.com/jcupitt/php-vips-ext.git"
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

php-vips is a PHP binding for the libvips image processing library.
It is typically 4x faster than imagick, 10x faster than gd, and
runs in 10x less memory. See:

https://github.com/jcupitt/php-vips-bench

This formula installs php-vips-ext, the extension part of php-vips.

https://github.com/jcupitt/php-vips-ext

You can then use php-vips with composer in the usual way.

https://github.com/jcupitt/php-vips