### PR TITLE
PHP 7.1.0RC6

### DIFF
--- a/Abstract/abstract-php-version.rb
+++ b/Abstract/abstract-php-version.rb
@@ -62,13 +62,13 @@ class AbstractPhpVersion < Formula
   end
 
   module Php71Defs
-    PHP_SRC_TARBALL = 'https://downloads.php.net/~krakjoe/php-7.1.0RC5.tar.bz2'
+    PHP_SRC_TARBALL = 'https://downloads.php.net/~krakjoe/php-7.1.0RC6.tar.bz2'
     PHP_GITHUB_URL  = 'https://github.com/php/php-src.git'
-    PHP_VERSION     = '7.1.0-rc.5'
+    PHP_VERSION     = '7.1.0-rc.6'
     PHP_BRANCH      = 'PHP-7.1'
 
     PHP_CHECKSUM    = {
-                        :sha256 => 'd10ccd643f81fd1bba5abc3307f7deb12731dce8a934b2ccfb1d3df1fa3ce717',
+                        :sha256 => '7ed531c0697350ee22ac2b5ae3caf6c50643e773a2a61aace990afe9be305d1b',
                       }
   end
 end

--- a/Formula/php71.rb
+++ b/Formula/php71.rb
@@ -3,6 +3,7 @@ require File.expand_path("../../Abstract/abstract-php", __FILE__)
 class Php71 < AbstractPhp
   init
   desc "PHP Version 7.1"
+  revision 10
   bottle do
     sha256 "b1403a54ff3ea687f26b1f721464585bbae51397b7b9e097bd7571387641df03" => :sierra
     sha256 "857a9ba56c5c15e1cb5c8d07f1cb73cbac93191e1825df6853557a4a42a47346" => :el_capitan
@@ -14,7 +15,6 @@ class Php71 < AbstractPhp
   url PHP_SRC_TARBALL
   sha256 PHP_CHECKSUM[:sha256]
   version PHP_VERSION
-  revision 9
 
   head PHP_GITHUB_URL, :branch => PHP_BRANCH
 


### PR DESCRIPTION
Closes #3765


- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
  - It fails with the same result as the former php71 and current php70 formula
    ```
    Header files that shadow system header files were installed to "/usr/local/Cellar/php71/7.1.0-rc.6_10/include"
    ```