### PR TITLE
php71-xdebug 2.5.0RC1 - Fixes Segfault in code coverage issue

### DIFF
--- a/Formula/php71-xdebug.rb
+++ b/Formula/php71-xdebug.rb
@@ -4,8 +4,8 @@ class Php71Xdebug < AbstractPhp71Extension
   init
   desc "Provides debugging and profiling capabilities."
   homepage "http://xdebug.org"
-  url "https://pecl.php.net/get/xdebug-2.4.0.tgz"
-  sha256 "3c4dcb2709d1653534e7cfaa546307041afd298ac48a3670183a12cfdb5eee05"
+  url "https://pecl.php.net/get/xdebug-2.5.0RC1.tgz"
+  sha256 "4b67bde62a32068cb48eaa5c683a390721e919f6b762d7da7ba1d72cdd01721a"
   head "https://github.com/xdebug/xdebug.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

Initial PHP 7.1 support comes with xdebug version 2.5.0RC1. This commit changes xdebug source package version in the formula. This version also fixes “Segfault in code coverage” issue.