### PR TITLE
php70-memcache (new formula)

### DIFF
--- a/Formula/php70-memcache.rb
+++ b/Formula/php70-memcache.rb
@@ -1,0 +1,21 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php70Memcache < AbstractPhp70Extension
+  init
+  desc "Interact with memcached through OO and procedural interfaces."
+  homepage "https://github.com/websupport-sk/pecl-memcache"
+  head "https://github.com/websupport-sk/pecl-memcache.git", :branch => "NON_BLOCKING_IO_php7"
+
+  def install
+    Dir.chdir "memcache-#{version}" unless build.head?
+
+    ENV.universal_binary if build.universal?
+
+    safe_phpize
+    system "./configure", "--prefix=#{prefix}",
+                          phpconfig
+    system "make"
+    prefix.install "modules/memcache.so"
+    write_config_file if build.with? "config-file"
+  end
+end


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

The formula does not pass strict audit because there is no stable tag, similar to existing `php-memcache`therefore I assumed that this is acceptable, although not great.

The only potential issue is that it uses not the original source code from PECL but a forked version since the code in PECL does not support php7 and it seems like it is not in the plans to do so (the beta version is in beta for the past 3 years).

However, seems like there are no other options because plenty of code in the wild depends on memcache.

Please let me know if I could improve the PR.

Thanks.