### PR TITLE
fix(arcanist): use stable git branch

### DIFF
--- a/Formula/arcanist.rb
+++ b/Formula/arcanist.rb
@@ -4,21 +4,11 @@ class Arcanist < Formula
   desc "Phabricator Arcanist Tool"
   homepage "https://secure.phabricator.com/book/phabricator/article/arcanist/"
 
-  stable do
-    url "https://github.com/phacility/arcanist/archive/conduit-5.tar.gz"
-    sha256 "81a9599f0799f4a2b77a01ddb35275894b82d8e51f437b51f9342affd029aa8b"
-
-    resource "libphutil" do
-      url "https://github.com/phacility/libphutil/archive/conduit-5.tar.gz"
-      sha256 "a4bc5d2e80ca3c127d26d7dd74ad4b979841c7a648a2891ef2affd6876af8b2b"
-    end
-  end
-
   head do
-    url "https://github.com/phacility/arcanist.git"
+    url "https://github.com/phacility/arcanist.git", :branch => "stable"
 
     resource "libphutil" do
-      url "https://github.com/phacility/libphutil.git"
+      url "https://github.com/phacility/libphutil.git", :branch => "stable"
     end
   end
 


### PR DESCRIPTION
The last releases of arcanist and its dependency libphutil are nearly 4
years old.  They're also out of sync, which breaks arcanist.  See
https://phabricator.wikimedia.org/T130325.

The arcanist [installation instructions](https://secure.phabricator.com/book/phabricator/article/arcanist/#installing-arcanist)
recommend installing from master HEAD, so installing from stable HEAD
seems to be as stable of a release as we're going to get.

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----
