### PR TITLE
remove --with-mysql compile option for PHP 5.5+

### DIFF
--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -298,12 +298,12 @@ INFO
     if build.with? 'libmysql'
       args << "--with-mysql-sock=/tmp/mysql.sock"
       args << "--with-mysqli=#{HOMEBREW_PREFIX}/bin/mysql_config"
-      args << "--with-mysql=#{HOMEBREW_PREFIX}" unless build.without? 'legacy-mysql' || php_version.start_with?('7')
+      args << "--with-mysql=#{HOMEBREW_PREFIX}" unless build.without? 'legacy-mysql' || php_version.start_with?('5.5', '5.6', '7')
       args << "--with-pdo-mysql=#{HOMEBREW_PREFIX}"
     elsif build.with? 'mysql'
       args << "--with-mysql-sock=/tmp/mysql.sock"
       args << "--with-mysqli=mysqlnd"
-      args << "--with-mysql=mysqlnd" unless build.without? 'legacy-mysql' || php_version.start_with?('7')
+      args << "--with-mysql=mysqlnd" unless build.without? 'legacy-mysql' || php_version.start_with?('5.5', '5.6', '7')
       args << "--with-pdo-mysql=mysqlnd"
     end
 


### PR DESCRIPTION
Support was deprecated in PHP 5.5

- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----
