### PR TITLE
Move include directory to a custom path

### DIFF
--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -366,7 +366,11 @@ INFO
 
   def _install
     system "./buildconf", "--force" if build.head?
-    system "./configure", *install_args()
+    # Pass custom includedir option to pass homebrew audit check
+    system "./configure", *install_args(), "--includedir=" + prefix/"homebrew_include"
+
+    # Move include directory to match includedir option and pass homebrew CI bot audit check
+    File.rename "include", "homebrew_include"
 
     if build.with?('httpd24') || build.with?('httpd22')
       # Use Homebrew prefix for the Apache libexec folder

--- a/Formula/php71.rb
+++ b/Formula/php71.rb
@@ -3,7 +3,7 @@ require File.expand_path("../../Abstract/abstract-php", __FILE__)
 class Php71 < AbstractPhp
   init
   desc "PHP Version 7.1"
-  revision 11
+  revision 12
   bottle do
     sha256 "8eb43129efbc17abaa2183b902e7b1dae682093c4c51ba494b577c65da6292e9" => :sierra
     sha256 "d939149711013b808eee94293b4f7cad1b105510a9c8388bb3860289a443b266" => :el_capitan


### PR DESCRIPTION
This will make php builds pass the audit check when upgrading
or bumping revisions.

- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----
This is an attempt to bypass the audit check in homebrew to able to properly test php builds since they all currently fail by default when the audit checks for the include files. This might not be merged after talking to @MikeMcQuaid who suggested that whitelisting the formulas might be another possible option since it could affect other modules and software.

As far as I can tell it properly updates the php-info and phpize commands which are both used to create the environment for compiling php modules. There might be other scenarios that fall outside of this. It might also lead to that we need to recompile all modules in the tap which also does not seem feasible.