### PR TITLE
Added PHP 7.1 missing formulas

### DIFF
--- a/Formula/php71-apcu-bc.rb
+++ b/Formula/php71-apcu-bc.rb
@@ -1,0 +1,50 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php71ApcuBc < AbstractPhp71Extension
+  init
+  desc "APC User Cache - BC"
+  homepage "https://pecl.php.net/package/apcu_bc"
+  url "https://pecl.php.net/get/apcu_bc-1.0.1.tgz"
+  sha256 "512674d891104d6da91811dbb89d28ab3faa356ee0ab4cbeae9bba9cf3e971cb"
+  head "https://github.com/krakjoe/apcu-bc.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "90e7b9b4090376d7677438e2c094c09717e554e2f480837614a7b4e79b5ad1a0" => :el_capitan
+    sha256 "b54b4f1acc267d44a865dcc7d672f7593599c76b3888122bd383c079e7043c7a" => :yosemite
+    sha256 "7e2b62455334fcfb60f3750464709f8b0f68181764a65c2fac5bdaf92c839bba" => :mavericks
+  end
+
+  depends_on "php71-apcu"
+
+  def install
+    Dir.chdir "apcu_bc-#{version}" unless build.head?
+
+    ENV.universal_binary if build.universal?
+
+    args = []
+    args << "--enable-apc"
+
+    safe_phpize
+
+    # link in the apcu extension headers
+    mkdir_p "ext/apcu"
+    cp Dir.glob("#{Formula["php71-apcu"].opt_prefix}/include/*.h"), "ext/apcu/"
+
+    system "./configure", "--prefix=#{prefix}",
+                          phpconfig,
+                          *args
+    system "make"
+    prefix.install "modules/apc.so"
+    write_config_file if build.with? "config-file"
+  end
+
+  def extension
+    "apc"
+  end
+
+  # This is changed so that it will be included after apcu
+  def config_filename
+    "ext-bc-" + extension + ".ini"
+  end
+end

--- a/Formula/php71-memcached.rb
+++ b/Formula/php71-memcached.rb
@@ -1,0 +1,167 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php71Memcached < AbstractPhp71Extension
+  init
+  desc "Memcached via libmemcached library"
+  homepage "https://pecl.php.net/package/memcached"
+  head "https://github.com/php-memcached-dev/php-memcached.git", :branch => "php7"
+
+  option "with-sasl", "Build with sasl support"
+
+  depends_on "pkg-config" => :build
+  depends_on "php71-igbinary"
+  depends_on "igbinary" => :build
+  if build.with? "sasl"
+    depends_on "libmemcached" => "with-sasl"
+  else
+    depends_on "libmemcached"
+  end
+
+  def install
+    Dir.chdir "memcached-#{version}" unless build.head?
+
+    ENV.universal_binary if build.universal?
+
+    args = []
+    args << "--with-libmemcached-dir=#{Formula["libmemcached"].opt_prefix}"
+    args << "--enable-memcached-igbinary"
+    args << "--disable-memcached-sasl" if build.without? "sasl"
+
+    safe_phpize
+
+    # Install symlink to igbinary headers inside memcached build directory
+    (Pathname.pwd/"ext").install_symlink Formula["igbinary"].opt_include/"php7" => "igbinary"
+
+    system "./configure", "--prefix=#{prefix}",
+                          phpconfig,
+                          *args
+    system "make"
+    prefix.install "modules/memcached.so"
+    write_config_file if build.with? "config-file"
+  end
+
+  def config_file
+    # Use upsteam defaults (https://github.com/php-memcached-dev/php-memcached/blob/2.2.0/memcached.ini)
+    # with default values pre-filled
+    super + <<-EOS.undent
+
+      ; Use session locking
+      ; valid values: On, Off
+      ; the default is On
+      memcached.sess_locking = On
+
+      ; Session spin lock retry wait time in microseconds.
+      ; Be carefull when setting this value.
+      ; Valid values are integers, where 0 is interpreted as
+      ; the default value. Negative values result in a reduces
+      ; locking to a try lock.
+      ; the default is 150000
+      memcached.sess_lock_wait_min = 150000
+
+      ; The maximum time, in seconds, to wait for a session lock
+      ; before timing out.
+      ; Setting to 0 results in default behavior, which is to
+      ; use max_execution_time.
+      memcached.sess_lock_max_wait_min = 0;
+
+      ; The time, in seconds, before a lock should release itself.
+      ; Setting to 0 results in the default behaviour, which is to
+      ; use the memcached.sess_lock_max_wait setting. If that is
+      ; also 0, max_execution_time will be used.
+      memcached.sess_lock_expire = 0;
+
+      ; memcached session key prefix
+      ; valid values are strings less than 219 bytes long
+      ; the default value is "memc.sess.key."
+      memcached.sess_prefix = "memc.sess.key."
+
+      ; memcached session consistent hash mode
+      ; if set to On, consistent hashing (libketama) is used
+      ; for session handling.
+      ; When consistent hashing is used, one can add or remove cache
+      ; node(s) without messing up too much with existing keys
+      ; default is Off
+      memcached.sess_consistent_hash = Off
+
+      ; Allow failed memcached server to automatically be removed
+      memcached.sess_remove_failed = 1
+
+      ; Write data to a number of additional memcached servers
+      ; This is "poor man's HA" as libmemcached calls it.
+      ; If this value is positive and sess_remove_failed is enabled
+      ; when a memcached server fails the session will continue to be available
+      ; from a replica. However, if the failed memcache server
+      ; becomes available again it will read the session from there
+      ; which could have old data or no data at all
+      memcached.sess_number_of_replicas = 0
+
+      ; memcached session binary mode
+      ; libmemcached replicas only work if binary mode is enabled
+      memcached.sess_binary = Off
+
+      ; memcached session replica read randomize
+      memcached.sess_randomize_replica_read = Off
+
+      ; memcached connect timeout value
+      ; In non-blocking mode this changes the value of the timeout
+      ; during socket connection in milliseconds. Specifying -1 means an infinite timeout.
+      memcached.sess_connect_timeout = 1000
+
+      ; Session SASL username
+      ; Both username and password need to be set for SASL to be enabled
+      ; In addition to this memcached.use_sasl needs to be on
+      memcached.sess_sasl_username = NULL
+
+      ; Session SASL password
+      memcached.sess_sasl_password = NULL
+
+      ; Set the compression type
+      ; valid values are: fastlz, zlib
+      ; the default is fastlz
+      memcached.compression_type = "fastlz"
+
+      ; Compression factor
+      ; Store compressed value only if the compression
+      ; factor (saving) exceeds the set limit.
+      ;
+      ;  store compressed if:
+      ;    plain_len > comp_len * factor
+      ;
+      ; the default value is 1.3 (23% space saving)
+      memcached.compression_factor = "1.3"
+
+      ; The compression threshold
+      ;
+      ; Do not compress serialized values below this threshold.
+      ; the default is 2000 bytes
+      memcached.compression_threshold = 2000
+
+      ; Set the default serializer for new memcached objects.
+      ; valid values are: php, igbinary, json, json_array, msgpack
+      ;
+      ; json - standard php JSON encoding. This serializer
+      ;        is fast and compact but only works on UTF-8
+      ;        encoded data and does not fully implement
+      ;        serializing. See the JSON extension.
+      ; json_array - as json, but decodes into arrays
+      ; php - the standard php serializer
+      ; igbinary - a binary serializer
+      ; msgpack - a cross-language binary serializer
+      ;
+      ; The default is igbinary if available, then msgpack if available, then php otherwise.
+      ; memcached.serializer = "igbinary"
+
+      ; Use SASL authentication for connections
+      ; valid values: On, Off
+      ; the default is Off
+      memcached.use_sasl = Off
+
+      ; The amount of retries for failed store commands.
+      ; This mechanism allows transparent fail-over to secondary servers when
+      ; set/increment/decrement/setMulti operations fail on the desired server in a multi-server
+      ; environment.
+      ; the default is 2
+      memcached.store_retry_count = 2
+    EOS
+  end
+end


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

Formula php71-memcached is [a denied pull request](https://github.com/Homebrew/homebrew-php/pull/3412), but can't understand why.

Since it is a HEAD only formula I installed it with the following command:
`brew install php71-memcached.rb --HEAD`