### PR TITLE
php70-mcrypt: rebuild bottle

### DIFF
--- a/Formula/php70-mcrypt.rb
+++ b/Formula/php70-mcrypt.rb
@@ -4,7 +4,7 @@ class Php70Mcrypt < AbstractPhp70Extension
   init
   desc "Interface to the mcrypt library"
   homepage "http://php.net/manual/en/book.mcrypt.php"
-  revision 7
+  revision 8
 
   bottle do
     sha256 "5fac453b4083c80be050fab54e706d9f693b90f159ff1823dd9a5e7f4e558b81" => :sierra


### PR DESCRIPTION
For some reason the ini file was missing from the bottle and
rebuilding it should solve the issue. Fixes #3951 .

- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----
