### PR TITLE
Add php70-memcache

### DIFF
--- a/Formula/php70-memcache.rb
+++ b/Formula/php70-memcache.rb
@@ -1,0 +1,22 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php70Memcache < AbstractPhp70Extension
+  init
+  desc "Memcache PHP extension"
+  homepage "https://github.com/websupport-sk/pecl-memcache"
+  url "https://github.com/websupport-sk/pecl-memcache/archive/4991c2fff22d00dc81014cc92d2da7077ef4bc86.tar.gz"
+  version "3.0.9.20160311"
+  sha256 "498ae2f3fde66b471eb8662efedfe5cb2f89f5fff725791ffddbcc7d94b7bf21"
+  head "https://github.com/websupport-sk/pecl-memcache.git", :branch => "NON_BLOCKING_IO_php7"
+
+  def install
+    ENV.universal_binary if build.universal?
+
+    safe_phpize
+    system "./configure", "--prefix=#{prefix}",
+                          phpconfig
+    system "make"
+    prefix.install "modules/memcache.so"
+    write_config_file if build.with? "config-file"
+  end
+end


### PR DESCRIPTION
It seems the memcache extension has not been packaged here for PHP 7 because the 2.x.x version fails to compile. However, I noticed [ubuntu do have it packaged](https://launchpad.net/ubuntu/+source/php-memcache) and found they were using a forked repo https://github.com/websupport-sk/pecl-memcache. Fedora seem to be using it too.

So here I've taken the same approach and am installing memcache from the fork.

- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?

This looks similar https://github.com/Homebrew/homebrew-php/pull/3860

- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

