### PR TITLE
Add mysql dependency for legacy mysql extension

### DIFF
--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -41,6 +41,7 @@ class AbstractPhp < Formula
     depends_on "libxml2" if build.include?("with-homebrew-libxml2") || MacOS.version < :lion || MacOS.version >= :el_capitan
     depends_on "unixodbc" unless build.include?("without-unixodbc")
     depends_on "readline"
+    depends_on "mysql" if build.include?("with-libmysql")
 
     # ssl
     if build.include?("with-homebrew-libressl")


### PR DESCRIPTION
The extension has been removed as of PHP 7 but needs the mysql
dependency to compile in older versions of PHP.

Closes #4076

- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----
