### PR TITLE
add apache tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A centralized repository for PHP-related brews.
 ## Requirements
 
 * [Homebrew](https://github.com/Homebrew/brew)
+* [homebrew Apache](https://github.com/Homebrew/homebrew-apache)
 * Yosemite, El Capitan, and Sierra. Untested everywhere else.
 
 ## Installation
@@ -12,6 +13,7 @@ A centralized repository for PHP-related brews.
 Run the following in your command-line:
 
 ```sh
+$ brew tap homebrew/homebrew-apache
 $ brew tap homebrew/homebrew-php
 ```
 


### PR DESCRIPTION
without this, it it gives me bogus error:

```
➔ brew install php56 
==> Installing php56 from homebrew/php
==> Tapping homebrew/apache
Cloning into '/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-apache'...
remote: Counting objects: 17, done.
remote: Compressing objects: 100% (16/16), done.
remote: Total 17 (delta 7), reused 6 (delta 1), pack-reused 0
Unpacking objects: 100% (17/17), done.
Error: Invalid formula: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-apache/mod_suexec.rb
formulae require at least a URL
Error: Cannot tap homebrew/apache: invalid syntax in tap!
```

```
➔ ls -l /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-apache/mod_suexec.rb
ls: cannot access '/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-apache/mod_suexec.rb': No such file or directory

➔ ls -l /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/
total 8
drwxrwxr-x  6 glen glen 4096 juuli  3 00:27 homebrew-core/
drwxrwxr-x 10 glen glen 4096 juuli  3 13:47 homebrew-php/
➔ 
```

```
➔ brew --version
Homebrew 1.2.2-1-g984d94c66-dirty
Homebrew/homebrew-core (git revision 55e6d5; last commit 2017-07-01)
```