### PR TITLE
Add php70-trader extension

### DIFF
--- a/Formula/php54-trader.rb
+++ b/Formula/php54-trader.rb
@@ -1,0 +1,22 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php54Trader < AbstractPhp54Extension
+  init
+  desc "Technical Analysis for traders"
+  homepage "https://pecl.php.net/package/trader"
+  url "https://pecl.php.net/get/trader-0.4.0.tgz"
+  sha256 "64400b2331cd843cd1bb684b5d02145ac6c00118565915fe592c6eee3c108784"
+
+  depends_on "ta-lib"
+  depends_on "libtool" => :run
+
+  def install
+    Dir.chdir "trader-#{version}"
+
+    safe_phpize
+    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "make"
+    prefix.install "modules/trader.so"
+    write_config_file if build.with? "config-file"
+  end
+end

--- a/Formula/php55-trader.rb
+++ b/Formula/php55-trader.rb
@@ -1,0 +1,22 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php55Trader < AbstractPhp55Extension
+  init
+  desc "Technical Analysis for traders"
+  homepage "https://pecl.php.net/package/trader"
+  url "https://pecl.php.net/get/trader-0.4.0.tgz"
+  sha256 "64400b2331cd843cd1bb684b5d02145ac6c00118565915fe592c6eee3c108784"
+
+  depends_on "ta-lib"
+  depends_on "libtool" => :run
+
+  def install
+    Dir.chdir "trader-#{version}"
+
+    safe_phpize
+    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "make"
+    prefix.install "modules/trader.so"
+    write_config_file if build.with? "config-file"
+  end
+end

--- a/Formula/php56-trader.rb
+++ b/Formula/php56-trader.rb
@@ -1,0 +1,22 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php56Trader < AbstractPhp56Extension
+  init
+  desc "Technical Analysis for traders"
+  homepage "https://pecl.php.net/package/trader"
+  url "https://pecl.php.net/get/trader-0.4.0.tgz"
+  sha256 "64400b2331cd843cd1bb684b5d02145ac6c00118565915fe592c6eee3c108784"
+
+  depends_on "ta-lib"
+  depends_on "libtool" => :run
+
+  def install
+    Dir.chdir "trader-#{version}"
+
+    safe_phpize
+    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "make"
+    prefix.install "modules/trader.so"
+    write_config_file if build.with? "config-file"
+  end
+end

--- a/Formula/php70-trader.rb
+++ b/Formula/php70-trader.rb
@@ -1,0 +1,22 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php70Trader < AbstractPhp70Extension
+  init
+  desc "Technical Analysis for traders"
+  homepage "https://pecl.php.net/package/trader"
+  url "https://pecl.php.net/get/trader-0.4.0.tgz"
+  sha256 "64400b2331cd843cd1bb684b5d02145ac6c00118565915fe592c6eee3c108784"
+
+  depends_on "ta-lib"
+  depends_on "libtool" => :run
+
+  def install
+    Dir.chdir "trader-#{version}"
+
+    safe_phpize
+    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "make"
+    prefix.install "modules/trader.so"
+    write_config_file if build.with? "config-file"
+  end
+end

--- a/Formula/php71-trader.rb
+++ b/Formula/php71-trader.rb
@@ -1,0 +1,22 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php71Trader < AbstractPhp71Extension
+  init
+  desc "Technical Analysis for traders"
+  homepage "https://pecl.php.net/package/trader"
+  url "https://pecl.php.net/get/trader-0.4.0.tgz"
+  sha256 "64400b2331cd843cd1bb684b5d02145ac6c00118565915fe592c6eee3c108784"
+
+  depends_on "ta-lib"
+  depends_on "libtool" => :run
+
+  def install
+    Dir.chdir "trader-#{version}"
+
+    safe_phpize
+    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "make"
+    prefix.install "modules/trader.so"
+    write_config_file if build.with? "config-file"
+  end
+end

--- a/Formula/php72-trader.rb
+++ b/Formula/php72-trader.rb
@@ -1,0 +1,22 @@
+require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
+
+class Php72Trader < AbstractPhp72Extension
+  init
+  desc "Technical Analysis for traders"
+  homepage "https://pecl.php.net/package/trader"
+  url "https://pecl.php.net/get/trader-0.4.0.tgz"
+  sha256 "64400b2331cd843cd1bb684b5d02145ac6c00118565915fe592c6eee3c108784"
+
+  depends_on "ta-lib"
+  depends_on "libtool" => :run
+
+  def install
+    Dir.chdir "trader-#{version}"
+
+    safe_phpize
+    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "make"
+    prefix.install "modules/trader.so"
+    write_config_file if build.with? "config-file"
+  end
+end


### PR DESCRIPTION
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----
Hello

This is my first contribution on brew, I still have a little problem, when I uninstall my php-trader extension, my `/usr/local/etc/php/7.0/conf.d/ext-trader.ini` still in the `conf.d` folder, how can I remove it automatically please?

Regards
