### PR TITLE
Add argon2 support for the base php72 formula. 

### DIFF
--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -250,7 +250,7 @@ INFO
     end
 
     # Build with argon2 support (Password Hashing API)
-    if build.with?("libargon")
+    if build.with?("argon2")
       args << "--with-password-argon2=#{Formula["argon2"].opt_prefix}"
     end
 

--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -52,6 +52,10 @@ class AbstractPhp < Formula
       depends_on "openssl"
     end
 
+    #argon for 7.2
+    depends_on "argon2" => :optional if build.include?("with-argon2") && name.split("::")[2].downcase.start_with?("php72")
+
+
     deprecated_option "with-pgsql" => "with-postgresql"
     depends_on :postgresql => :optional
 
@@ -70,6 +74,11 @@ class AbstractPhp < Formula
 
     depends_on "homebrew/apache/httpd24" => :optional
     depends_on "homebrew/apache/httpd22" => :optional
+
+    # Argon2 option
+    if name.split("::")[2].downcase.start_with?("php72")
+      option "with-argon2", "Include libargon2 password hashing support"
+    end
 
     option "with-cgi", "Enable building of the CGI executable (implies --without-fpm)"
     option "with-debug", "Compile with debugging symbols"
@@ -237,6 +246,11 @@ INFO
     unless build.without? "unixodbc"
       args << "--with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}"
       args << "--with-unixODBC=#{Formula["unixodbc"].opt_prefix}"
+    end
+
+    # Build with argon2 support (Password Hashing API)
+    if build.with?("libargon")
+      args << "--with-password-argon2=#{Formula["argon2"].opt_prefix}"
     end
 
     # Build Apache module by default

--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -53,7 +53,8 @@ class AbstractPhp < Formula
     end
 
     #argon for 7.2
-    depends_on "argon2" => :optional if build.include?("with-argon2") && name.split("::")[2].downcase.start_with?("php72")
+    depends_on "argon2" => :optional if build.include?("with-argon2")
+
 
 
     deprecated_option "with-pgsql" => "with-postgresql"


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)? Not sure this should pass sense php72 is still beta? 

-----
Hello guys. 
I finally got around to make a pr for the argon2 stuff. I have added a new option flag (--with-argon2) which is only visible if the formula you are installing is php72. 

Reference https://github.com/Homebrew/homebrew-php/issues/4210

CC @javian. 

