### PR TITLE
php56-ioncubeloader 10.0.2

### DIFF
--- a/Formula/php53-ioncubeloader.rb
+++ b/Formula/php53-ioncubeloader.rb
@@ -5,8 +5,8 @@ class Php53Ioncubeloader < AbstractPhp53Extension
   desc "Loader for ionCube Secured Files"
   homepage "http://www.ioncube.com/loaders.php"
   url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "1c9b17a4750578299277cc69631769ecc63708da0b12253cb333434add10332a"
-  version "6.0.9"
+  sha256 "e5683c7340f6f6b98de36d9afdd961aa8d2c7949432868502b84a43959802c0d"
+  version "10.0.2"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/php53-ioncubeloader.rb
+++ b/Formula/php53-ioncubeloader.rb
@@ -3,10 +3,10 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 class Php53Ioncubeloader < AbstractPhp53Extension
   init
   desc "Loader for ionCube Secured Files"
-  homepage "https://www.ioncube.com/loaders.php"
-  url "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "af0b548d0e27e6fea9f0b5ee73b2c2099e1cd67f6dd9fd74d2e718ff151d994f"
-  version "10.0.3"
+  homepage "http://www.ioncube.com/loaders.php"
+  url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
+  sha256 "1c9b17a4750578299277cc69631769ecc63708da0b12253cb333434add10332a"
+  version "6.0.9"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/php53-ioncubeloader.rb
+++ b/Formula/php53-ioncubeloader.rb
@@ -3,10 +3,10 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 class Php53Ioncubeloader < AbstractPhp53Extension
   init
   desc "Loader for ionCube Secured Files"
-  homepage "http://www.ioncube.com/loaders.php"
-  url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "e5683c7340f6f6b98de36d9afdd961aa8d2c7949432868502b84a43959802c0d"
-  version "10.0.2"
+  homepage "https://www.ioncube.com/loaders.php"
+  url "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
+  sha256 "af0b548d0e27e6fea9f0b5ee73b2c2099e1cd67f6dd9fd74d2e718ff151d994f"
+  version "10.0.3"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/php54-ioncubeloader.rb
+++ b/Formula/php54-ioncubeloader.rb
@@ -3,10 +3,10 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 class Php54Ioncubeloader < AbstractPhp54Extension
   init
   desc "Loader for ionCube Secured Files"
-  homepage "http://www.ioncube.com/loaders.php"
-  url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "e5683c7340f6f6b98de36d9afdd961aa8d2c7949432868502b84a43959802c0d"
-  version "10.0.2"
+  homepage "https://www.ioncube.com/loaders.php"
+  url "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
+  sha256 "af0b548d0e27e6fea9f0b5ee73b2c2099e1cd67f6dd9fd74d2e718ff151d994f"
+  version "10.0.3"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/php54-ioncubeloader.rb
+++ b/Formula/php54-ioncubeloader.rb
@@ -5,8 +5,8 @@ class Php54Ioncubeloader < AbstractPhp54Extension
   desc "Loader for ionCube Secured Files"
   homepage "http://www.ioncube.com/loaders.php"
   url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "1c9b17a4750578299277cc69631769ecc63708da0b12253cb333434add10332a"
-  version "6.0.9"
+  sha256 "e5683c7340f6f6b98de36d9afdd961aa8d2c7949432868502b84a43959802c0d"
+  version "10.0.2"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/php55-ioncubeloader.rb
+++ b/Formula/php55-ioncubeloader.rb
@@ -5,8 +5,8 @@ class Php55Ioncubeloader < AbstractPhp55Extension
   desc "Loader for ionCube Secured Files"
   homepage "http://www.ioncube.com/loaders.php"
   url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "1c9b17a4750578299277cc69631769ecc63708da0b12253cb333434add10332a"
-  version "6.0.9"
+  sha256 "e5683c7340f6f6b98de36d9afdd961aa8d2c7949432868502b84a43959802c0d"
+  version "10.0.2"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/php55-ioncubeloader.rb
+++ b/Formula/php55-ioncubeloader.rb
@@ -3,10 +3,10 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 class Php55Ioncubeloader < AbstractPhp55Extension
   init
   desc "Loader for ionCube Secured Files"
-  homepage "http://www.ioncube.com/loaders.php"
-  url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "e5683c7340f6f6b98de36d9afdd961aa8d2c7949432868502b84a43959802c0d"
-  version "10.0.2"
+  homepage "https://www.ioncube.com/loaders.php"
+  url "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
+  sha256 "af0b548d0e27e6fea9f0b5ee73b2c2099e1cd67f6dd9fd74d2e718ff151d994f"
+  version "10.0.3"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/php56-ioncubeloader.rb
+++ b/Formula/php56-ioncubeloader.rb
@@ -5,7 +5,7 @@ class Php56Ioncubeloader < AbstractPhp56Extension
   desc "Loader for ionCube Secured Files"
   homepage "http://www.ioncube.com/loaders.php"
   url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "1845c9859ed4d049ddd26fa75a82cadbb4b7b30647dd42971adbc5479bfa344a"
+  sha256 "e5683c7340f6f6b98de36d9afdd961aa8d2c7949432868502b84a43959802c0d"
   version "10.0.2"
 
   bottle do

--- a/Formula/php56-ioncubeloader.rb
+++ b/Formula/php56-ioncubeloader.rb
@@ -3,10 +3,10 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 class Php56Ioncubeloader < AbstractPhp56Extension
   init
   desc "Loader for ionCube Secured Files"
-  homepage "http://www.ioncube.com/loaders.php"
-  url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "e5683c7340f6f6b98de36d9afdd961aa8d2c7949432868502b84a43959802c0d"
-  version "10.0.2"
+  homepage "https://www.ioncube.com/loaders.php"
+  url "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
+  sha256 "af0b548d0e27e6fea9f0b5ee73b2c2099e1cd67f6dd9fd74d2e718ff151d994f"
+  version "10.0.3"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/php56-ioncubeloader.rb
+++ b/Formula/php56-ioncubeloader.rb
@@ -5,8 +5,8 @@ class Php56Ioncubeloader < AbstractPhp56Extension
   desc "Loader for ionCube Secured Files"
   homepage "http://www.ioncube.com/loaders.php"
   url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "1c9b17a4750578299277cc69631769ecc63708da0b12253cb333434add10332a"
-  version "6.0.9"
+  sha256 "1845c9859ed4d049ddd26fa75a82cadbb4b7b30647dd42971adbc5479bfa344a"
+  version "10.0.2"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/php70-ioncubeloader.rb
+++ b/Formula/php70-ioncubeloader.rb
@@ -5,8 +5,8 @@ class Php70Ioncubeloader < AbstractPhp70Extension
   desc "Loader for ionCube Secured Files"
   homepage "http://www.ioncube.com/loaders.php"
   url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "1c9b17a4750578299277cc69631769ecc63708da0b12253cb333434add10332a"
-  version "6.0.9"
+  sha256 "e5683c7340f6f6b98de36d9afdd961aa8d2c7949432868502b84a43959802c0d"
+  version "10.0.2"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/php70-ioncubeloader.rb
+++ b/Formula/php70-ioncubeloader.rb
@@ -3,10 +3,10 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 class Php70Ioncubeloader < AbstractPhp70Extension
   init
   desc "Loader for ionCube Secured Files"
-  homepage "http://www.ioncube.com/loaders.php"
-  url "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "e5683c7340f6f6b98de36d9afdd961aa8d2c7949432868502b84a43959802c0d"
-  version "10.0.2"
+  homepage "https://www.ioncube.com/loaders.php"
+  url "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
+  sha256 "af0b548d0e27e6fea9f0b5ee73b2c2099e1cd67f6dd9fd74d2e718ff151d994f"
+  version "10.0.3"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/php71-ioncubeloader.rb
+++ b/Formula/php71-ioncubeloader.rb
@@ -3,10 +3,10 @@ require File.expand_path("../../Abstract/abstract-php-extension", __FILE__)
 class Php71Ioncubeloader < AbstractPhp71Extension
   init
   desc "Loader for ionCube Secured Files"
-  homepage "http://www.ioncube.com/loaders.php"
+  homepage "https://www.ioncube.com/loaders.php"
   url "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "e5683c7340f6f6b98de36d9afdd961aa8d2c7949432868502b84a43959802c0d"
-  version "10.0.2"
+  sha256 "af0b548d0e27e6fea9f0b5ee73b2c2099e1cd67f6dd9fd74d2e718ff151d994f"
+  version "10.0.3"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/php71-ioncubeloader.rb
+++ b/Formula/php71-ioncubeloader.rb
@@ -5,8 +5,8 @@ class Php71Ioncubeloader < AbstractPhp71Extension
   desc "Loader for ionCube Secured Files"
   homepage "http://www.ioncube.com/loaders.php"
   url "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz"
-  sha256 "2a5975464e651ae7f8a3c166cbafcd36e9dc4bfba94e9fa2a0f58c91ba3ae3b6"
-  version "10.0.0"
+  sha256 "e5683c7340f6f6b98de36d9afdd961aa8d2c7949432868502b84a43959802c0d"
+  version "10.0.2"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
updated ionCube loaders to latest released version 10.0.2 per ionCube site

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----
