### PR TITLE
Fix installation of php-libsodium formulas for non-/usr/local installations

### DIFF
--- a/Formula/php54-libsodium.rb
+++ b/Formula/php54-libsodium.rb
@@ -21,7 +21,10 @@ class Php54Libsodium < AbstractPhp54Extension
     ENV.universal_binary if build.universal?
 
     safe_phpize
-    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "./configure",
+      "--with-libsodium=#{Formula["libsodium"].opt_prefix}",
+      "--prefix=#{prefix}",
+      phpconfig
     system "make"
     prefix.install "modules/libsodium.so"
     write_config_file if build.with? "config-file"

--- a/Formula/php54-libsodium.rb
+++ b/Formula/php54-libsodium.rb
@@ -9,7 +9,6 @@ class Php54Libsodium < AbstractPhp54Extension
   head "https://github.com/jedisct1/libsodium-php.git"
 
   bottle do
-    cellar :any
     sha256 "1061c578396cb39f1f342e41835a46d3753fd7cc23b12af61523243bfb4b2b8c" => :el_capitan
     sha256 "955a7465b51940fafcdf37004f970c4c1db448468a560d4e998f8781e67166ef" => :yosemite
     sha256 "85cddcbb72a64797b079fa1ab844a4a5f69625e23c259a41fa102b2d6030aefb" => :mavericks

--- a/Formula/php54-sodium.rb
+++ b/Formula/php54-sodium.rb
@@ -21,7 +21,10 @@ class Php54Sodium < AbstractPhp54Extension
     ENV.universal_binary if build.universal?
 
     safe_phpize
-    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "./configure",
+      "--with-sodium=#{Formula["libsodium"].opt_prefix}",
+      "--prefix=#{prefix}",
+      phpconfig
     system "make"
     prefix.install "modules/sodium.so"
     write_config_file if build.with? "config-file"

--- a/Formula/php55-libsodium.rb
+++ b/Formula/php55-libsodium.rb
@@ -9,7 +9,6 @@ class Php55Libsodium < AbstractPhp55Extension
   head "https://github.com/jedisct1/libsodium-php.git"
 
   bottle do
-    cellar :any
     sha256 "b1dd0916b4ef9f9567f3c528113310a2526615e40ff282d7152e7d6a5ce2da58" => :el_capitan
     sha256 "b0685f2b5609290784bd9ffb1c488c03eb7c08194cf50857389ecdd0114f0840" => :yosemite
     sha256 "edd7fab6cc0c13d59d5c60016210f70f5daf540978cb9edf9eb7b5f1eb035750" => :mavericks

--- a/Formula/php55-libsodium.rb
+++ b/Formula/php55-libsodium.rb
@@ -21,7 +21,10 @@ class Php55Libsodium < AbstractPhp55Extension
     ENV.universal_binary if build.universal?
 
     safe_phpize
-    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "./configure",
+      "--with-libsodium=#{Formula["libsodium"].opt_prefix}",
+      "--prefix=#{prefix}",
+      phpconfig
     system "make"
     prefix.install "modules/libsodium.so"
     write_config_file if build.with? "config-file"

--- a/Formula/php55-sodium.rb
+++ b/Formula/php55-sodium.rb
@@ -21,7 +21,10 @@ class Php55Sodium < AbstractPhp55Extension
     ENV.universal_binary if build.universal?
 
     safe_phpize
-    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "./configure",
+      "--with-sodium=#{Formula["libsodium"].opt_prefix}",
+      "--prefix=#{prefix}",
+      phpconfig
     system "make"
     prefix.install "modules/sodium.so"
     write_config_file if build.with? "config-file"

--- a/Formula/php56-libsodium.rb
+++ b/Formula/php56-libsodium.rb
@@ -21,7 +21,10 @@ class Php56Libsodium < AbstractPhp56Extension
     ENV.universal_binary if build.universal?
 
     safe_phpize
-    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "./configure",
+      "--with-libsodium=#{Formula["libsodium"].opt_prefix}",
+      "--prefix=#{prefix}",
+      phpconfig
     system "make"
     prefix.install "modules/libsodium.so"
     write_config_file if build.with? "config-file"

--- a/Formula/php56-libsodium.rb
+++ b/Formula/php56-libsodium.rb
@@ -9,7 +9,6 @@ class Php56Libsodium < AbstractPhp56Extension
   head "https://github.com/jedisct1/libsodium-php.git"
 
   bottle do
-    cellar :any
     sha256 "b72ca95adc0312a6b5c07dde8498c18d41e7299c88016c77702a355c7aa3d250" => :el_capitan
     sha256 "bf6915e807c4f0e937e38ced15f101044f87bab531dbd76c6b9a991fcbad5130" => :yosemite
     sha256 "8479fce9fa1c01d47464fc69252f08e0bf4d3bc500fadbc98c5c6ac7917f2599" => :mavericks

--- a/Formula/php56-sodium.rb
+++ b/Formula/php56-sodium.rb
@@ -21,7 +21,10 @@ class Php56Sodium < AbstractPhp56Extension
     ENV.universal_binary if build.universal?
 
     safe_phpize
-    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "./configure",
+      "--with-sodium=#{Formula["libsodium"].opt_prefix}",
+      "--prefix=#{prefix}",
+      phpconfig
     system "make"
     prefix.install "modules/sodium.so"
     write_config_file if build.with? "config-file"

--- a/Formula/php70-libsodium@1.0.rb
+++ b/Formula/php70-libsodium@1.0.rb
@@ -9,7 +9,6 @@ class Php70LibsodiumAT10 < AbstractPhp70Extension
   head "https://github.com/jedisct1/libsodium-php.git"
 
   bottle do
-    cellar :any
     sha256 "4bae0ed5e848b2796f5b1ee4b9387202bf073f59fb4c668c05a9f083e34d2488" => :high_sierra
     sha256 "4b89ebd33f69633f40a9d08137ae6f25f6c67e7ab5fcf79b67c7b638232af30f" => :sierra
     sha256 "aadc58d407edd8bf144e4bc9c2d155581f530b51c78e6b65262df53713bbe168" => :el_capitan

--- a/Formula/php70-libsodium@1.0.rb
+++ b/Formula/php70-libsodium@1.0.rb
@@ -23,7 +23,10 @@ class Php70LibsodiumAT10 < AbstractPhp70Extension
 
   def install
     safe_phpize
-    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "./configure",
+      "--with-libsodium=#{Formula["libsodium"].opt_prefix}",
+      "--prefix=#{prefix}",
+      phpconfig
     system "make"
     prefix.install "modules/libsodium.so"
     write_config_file if build.with? "config-file"

--- a/Formula/php70-sodium.rb
+++ b/Formula/php70-sodium.rb
@@ -9,7 +9,6 @@ class Php70Sodium < AbstractPhp70Extension
   head "https://github.com/jedisct1/libsodium-php.git"
 
   bottle do
-    cellar :any
     sha256 "b4199152b62f37af8be60d4906cb35fbc5d80dca50af9e0a317289d4806bc63d" => :high_sierra
     sha256 "6877d35baac5b94d71c122a70779b14073c32590b5d69f70ba8ef2be40740d65" => :sierra
     sha256 "413bdff00df34c54066872fce1fcbb934d179e2c66223344d4fdd7d420fd2e03" => :el_capitan

--- a/Formula/php70-sodium.rb
+++ b/Formula/php70-sodium.rb
@@ -19,7 +19,10 @@ class Php70Sodium < AbstractPhp70Extension
 
   def install
     safe_phpize
-    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "./configure",
+      "--with-sodium=#{Formula["libsodium"].opt_prefix}",
+      "--prefix=#{prefix}",
+      phpconfig
     system "make"
     prefix.install "modules/sodium.so"
     write_config_file if build.with? "config-file"

--- a/Formula/php71-libsodium@1.0.rb
+++ b/Formula/php71-libsodium@1.0.rb
@@ -9,7 +9,6 @@ class Php71LibsodiumAT10 < AbstractPhp71Extension
   head "https://github.com/jedisct1/libsodium-php.git"
 
   bottle do
-    cellar :any
     sha256 "74d31706bb4daeb74f619b149f686334e7317cfa7e8530e50fbd42697873ff77" => :high_sierra
     sha256 "2aed03ae0d8970032147356a577f68809cc28d8ac3500f19f1ad451a10ebfa17" => :sierra
     sha256 "7289833eefccf59bad857d2db7d7e74489c2d37ebd39812f7ec2cbb767ddb2bc" => :el_capitan

--- a/Formula/php71-libsodium@1.0.rb
+++ b/Formula/php71-libsodium@1.0.rb
@@ -23,7 +23,10 @@ class Php71LibsodiumAT10 < AbstractPhp71Extension
 
   def install
     safe_phpize
-    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "./configure",
+      "--with-libsodium=#{Formula["libsodium"].opt_prefix}",
+      "--prefix=#{prefix}",
+      phpconfig
     system "make"
     prefix.install "modules/libsodium.so"
     write_config_file if build.with? "config-file"

--- a/Formula/php71-sodium.rb
+++ b/Formula/php71-sodium.rb
@@ -19,7 +19,10 @@ class Php71Sodium < AbstractPhp71Extension
 
   def install
     safe_phpize
-    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "./configure",
+      "--with-sodium=#{Formula["libsodium"].opt_prefix}",
+      "--prefix=#{prefix}",
+      phpconfig
     system "make"
     prefix.install "modules/sodium.so"
     write_config_file if build.with? "config-file"

--- a/Formula/php71-sodium.rb
+++ b/Formula/php71-sodium.rb
@@ -9,7 +9,6 @@ class Php71Sodium < AbstractPhp71Extension
   head "https://github.com/jedisct1/libsodium-php.git"
 
   bottle do
-    cellar :any
     sha256 "27a30369b7e320a5d07184712cdecdb445feabb32616143ca2abc73b4059aa8e" => :high_sierra
     sha256 "12ff2763fcf8536f0e1047d3ab7a31497aa285a1071826a1a4e009aaa1e7300c" => :sierra
     sha256 "0f5150555bcf071457d92993dd78af4dc2ea24c6b41961f75f84df3b478c69bf" => :el_capitan


### PR DESCRIPTION
Fix installation of php-libsodium formulas for non-/usr/local installations

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
