### PR TITLE
php7x-ssh2 update to 1.1.2

### DIFF
--- a/Formula/php70-ssh2.rb
+++ b/Formula/php70-ssh2.rb
@@ -4,8 +4,8 @@ class Php70Ssh2 < AbstractPhp70Extension
   init
   desc "Provides bindings to the functions of libssh2"
   homepage "https://pecl.php.net/package/ssh2"
-  url "https://pecl.php.net/get/ssh2-1.0.tgz"
-  sha256 "6a93891878b23904a773eb814fec7aea4ea00b4a412ee779c8535ed9c5e46ced"
+  url "https://pecl.php.net/get/ssh2-1.1.2.tgz"
+  sha256 "87618d6a0981afe8c24b36d6b38c21a0aa0237b62e60347d0170bd86b51f79fb"
   head "https://github.com/php/pecl-networking-ssh2.git"
 
   bottle do
@@ -18,9 +18,7 @@ class Php70Ssh2 < AbstractPhp70Extension
 
   def install
     Dir.chdir "ssh2-#{version}" unless build.head?
-
-    ENV.universal_binary if build.universal?
-
+    
     safe_phpize
     system "./configure", "--prefix=#{prefix}",
                           phpconfig,

--- a/Formula/php71-ssh2.rb
+++ b/Formula/php71-ssh2.rb
@@ -4,8 +4,8 @@ class Php71Ssh2 < AbstractPhp71Extension
   init
   desc "Provides bindings to the functions of libssh2"
   homepage "https://pecl.php.net/package/ssh2"
-  url "https://pecl.php.net/get/ssh2-1.0.tgz"
-  sha256 "6a93891878b23904a773eb814fec7aea4ea00b4a412ee779c8535ed9c5e46ced"
+  url "https://pecl.php.net/get/ssh2-1.1.2.tgz"
+  sha256 "87618d6a0981afe8c24b36d6b38c21a0aa0237b62e60347d0170bd86b51f79fb"
   head "https://github.com/php/pecl-networking-ssh2.git"
 
   bottle do
@@ -18,9 +18,7 @@ class Php71Ssh2 < AbstractPhp71Extension
 
   def install
     Dir.chdir "ssh2-#{version}" unless build.head?
-
-    ENV.universal_binary if build.universal?
-
+    
     safe_phpize
     system "./configure", "--prefix=#{prefix}",
                           phpconfig,

--- a/Formula/php72-ssh2.rb
+++ b/Formula/php72-ssh2.rb
@@ -4,10 +4,9 @@ class Php72Ssh2 < AbstractPhp72Extension
   init
   desc "Provides bindings to the functions of libssh2"
   homepage "https://pecl.php.net/package/ssh2"
-  url "https://pecl.php.net/get/ssh2-1.0.tgz"
-  sha256 "6a93891878b23904a773eb814fec7aea4ea00b4a412ee779c8535ed9c5e46ced"
+  url "https://pecl.php.net/get/ssh2-1.1.2.tgz"
+  sha256 "87618d6a0981afe8c24b36d6b38c21a0aa0237b62e60347d0170bd86b51f79fb"
   head "https://github.com/php/pecl-networking-ssh2.git"
-  revision 1
 
   bottle do
     sha256 "7e9924b10c4712501678ceba05d093fa7a23dedd925d879dcb4d2106ca02cc30" => :high_sierra


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

This fixes #3852 even if I'm not even sure that's an issue anymore. It also updates to a new version marked alpha but we were distributing alpha builds anyways.