### PR TITLE
Build libsodium on 7.2 unless --without-sodium

### DIFF
--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -55,7 +55,8 @@ class AbstractPhp < Formula
     #argon for 7.2
     depends_on "argon2" => :optional if build.include?("with-argon2")
 
-
+    # libsodium for 7.2
+    depends_on "libsodium" => :recommended if name.split("::")[2].downcase.start_with?("php72")
 
     deprecated_option "with-pgsql" => "with-postgresql"
     depends_on :postgresql => :optional
@@ -385,6 +386,10 @@ INFO
 
     if build.with? "thread-safety"
       args << "--enable-maintainer-zts"
+    end
+
+    if build.with? "sodium" 
+        args << "--with-sodium=#{Formula['libsodium'].opt_prefix}"
     end
 
     args


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

Ref: https://github.com/Homebrew/homebrew-php/issues/4536

I'm not a ruby user, and I couldnt see a good way of doing this without being specific to 7.2 that didnt end up being a mess of conditions in multiple places. I thought it might work if the condition was something like `php != 5 && php != 7.0 && php != 7.1` but it seems hackish.
