### PR TITLE
Build PHP 7.2 with libsodium by default

### DIFF
--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -397,7 +397,7 @@ INFO
       args << "--enable-maintainer-zts"
     end
 
-    if build.with? "sodium"
+    unless build.without? "libsodium"
         args << "--with-sodium=#{Formula['libsodium'].opt_prefix}"
     end
 


### PR DESCRIPTION
I don't understand the structure of brew formulae completely, but it seems that when the `depends_on "libsodium" => :recommended if name.split("::")[2].downcase.start_with?("php72")` is added, homebrew will automatically add an option `--without-libsodium`. With that said, the current check `if build.with? "sodium"` never gets to true. Changing to `unless build.without? "libsodium"` works for me locally.

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----
