### PR TITLE
Add support for the embed SAPI

### DIFF
--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -84,6 +84,7 @@ class AbstractPhp < Formula
 
     option "with-cgi", "Enable building of the CGI executable (implies --without-fpm)"
     option "with-debug", "Compile with debugging symbols"
+    option "with-embed", "Compile with embed support (built as a static library)"
     option "with-homebrew-curl", "Include Curl support via Homebrew"
     option "with-homebrew-libressl", "Include LibreSSL instead of OpenSSL via Homebrew"
     option "with-homebrew-libxslt", "Include LibXSLT support via Homebrew"
@@ -276,6 +277,10 @@ INFO
 
     if build.with? "debug"
       args << "--enable-debug"
+    end
+
+    if build.with? "embed"
+      args << "--enable-embed=static"
     end
 
     if build.with? "enchant"


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

This PR adds support for building the embed SAPI (disabled by default). Users may choose either static or shared builds.

I've tested this on PHP 5.3, 7.1, and 7.2. I'm comfortable that the versions between those will be OK too. This _seems_ to play OK with the multi-SAPI patch that gets applied to 5.3, but I won't pretend that I've exhaustively tested the various combinations, and that patch scares me a bit in general.

I've reviewed #1183 and believe I've addressed the feedback in that PR. Merging this would also fix #4557.