### PR TITLE
php71-intl version bump

### DIFF
--- a/Formula/php71-intl.rb
+++ b/Formula/php71-intl.rb
@@ -4,7 +4,7 @@ class Php71Intl < AbstractPhp71Extension
   init
   desc "Wrapper for the ICU library"
   homepage "https://php.net/manual/en/book.intl.php"
-  revision 22
+  revision 23
 
   bottle do
     sha256 "86269a5d6ba196588756d4556a0aa1d66e80698f16a65ceeabccf2b80c46e81a" => :high_sierra


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----
This fixes the following problem:
```
Warning: PHP Startup: Unable to load dynamic library '/usr/local/opt/php71-intl/intl.so' - dlopen(/usr/local/opt/php71-intl/intl.so, 9): Library not loaded: /usr/local/opt/icu4c/lib/libicudata.60.1.dylib
  Referenced from: /usr/local/opt/php71-intl/intl.so
  Reason: image not found in Unknown on line 0
```