### PR TITLE
Include --with-libzip option.

### DIFF
--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -59,7 +59,7 @@ class AbstractPhp < Formula
     depends_on "libsodium" => :recommended if name.split("::")[2].downcase.start_with?("php72")
 
     # libzip if required
-    depends_on "libzip" => :optional if name.split("::")[2].downcase.start_with?("php56", "php7")
+    depends_on "libzip" => :recommended if name.split("::")[2].downcase.start_with?("php56", "php7")
 
     deprecated_option "with-pgsql" => "with-postgresql"
     depends_on "postgresql" => :optional
@@ -101,7 +101,6 @@ class AbstractPhp < Formula
       option "with-phpdbg", "Enable building of the phpdbg SAPI executable"
     end
     option "with-thread-safety", "Build with thread safety"
-    option "with-libzip", "Include Libzip support via Homebrew"
     option "without-bz2", "Build without bz2 support"
     option "without-fpm", "Disable building of the fpm SAPI executable"
     option "without-ldap", "Build without LDAP support"

--- a/Abstract/abstract-php.rb
+++ b/Abstract/abstract-php.rb
@@ -58,6 +58,9 @@ class AbstractPhp < Formula
     # libsodium for 7.2
     depends_on "libsodium" => :recommended if name.split("::")[2].downcase.start_with?("php72")
 
+    # libzip if required
+    depends_on "libzip" => :optional if name.split("::")[2].downcase.start_with?("php56", "php7")
+
     deprecated_option "with-pgsql" => "with-postgresql"
     depends_on "postgresql" => :optional
 
@@ -98,6 +101,7 @@ class AbstractPhp < Formula
       option "with-phpdbg", "Enable building of the phpdbg SAPI executable"
     end
     option "with-thread-safety", "Build with thread safety"
+    option "with-libzip", "Include Libzip support via Homebrew"
     option "without-bz2", "Build without bz2 support"
     option "without-fpm", "Disable building of the fpm SAPI executable"
     option "without-ldap", "Build without LDAP support"
@@ -404,6 +408,10 @@ INFO
 
     if build.with? "libsodium"
         args << "--with-sodium=#{Formula['libsodium'].opt_prefix}"
+    end
+
+    if build.with? "libzip"
+        args << "--with-libzip=#{Formula['libzip'].opt_prefix}"
     end
 
     args

--- a/Formula/php72.rb
+++ b/Formula/php72.rb
@@ -3,7 +3,7 @@ require File.expand_path("../../Abstract/abstract-php", __FILE__)
 class Php72 < AbstractPhp
   init
   desc "PHP Version 7.2"
-  revision 13
+  revision 14
 
   bottle do
     sha256 "e60d5ee36a77c2106d892d9088af9bc0c0e77fa84eef1b5fdb517718de9dfd3f" => :high_sierra


### PR DESCRIPTION
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

This adds the ability to build against a Homebrew-installed version of the `libzip` library - providing access to some of the newer functionality within the `ZipArchive` extension (eg [setEncryptionName()](http://php.net/manual/en/ziparchive.setencryptionname.php).

PHP 7.2 requires building against libzip 1.2.0 for the encryption-based methods (see the PHP [UPGRADING](https://github.com/php/php-src/blob/php-7.2.0/UPGRADING#L148) document accordingly), so I'm not sure if this can be accomplished in some other more Homebrew-like way - please forgive my inexperience with delving into Homebrew formulas here! 🙂 