### PR TITLE
php7{1-2}-spx 0.2.2 (new formula)

### DIFF
--- a/Formula/php71-spx.rb
+++ b/Formula/php71-spx.rb
@@ -1,0 +1,20 @@
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+class Php71Spx < AbstractPhp71Extension
+  init
+  desc "SPX PHP extension"
+  homepage "https://github.com/NoiseByNorthwest/php-spx"
+  url "https://github.com/NoiseByNorthwest/php-spx/archive/v0.2.2.tar.gz"
+  sha256 "7ad22c84258f63a2130c596ec93269f8a0be7ce42629aed8430a388c0162c7cf"
+  head "https://github.com/NoiseByNorthwest/php-spx.git"
+
+  def install
+    ENV.universal_binary if build.universal?
+
+    safe_phpize
+    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "make"
+    prefix.install "modules/spx.so"
+    write_config_file if build.with? "config-file"
+  end
+end

--- a/Formula/php72-spx.rb
+++ b/Formula/php72-spx.rb
@@ -1,0 +1,20 @@
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+class Php72Spx < AbstractPhp72Extension
+  init
+  desc "SPX PHP extension"
+  homepage "https://github.com/NoiseByNorthwest/php-spx"
+  url "https://github.com/NoiseByNorthwest/php-spx/archive/v0.2.2.tar.gz"
+  sha256 "7ad22c84258f63a2130c596ec93269f8a0be7ce42629aed8430a388c0162c7cf"
+  head "https://github.com/NoiseByNorthwest/php-spx.git"
+
+  def install
+    ENV.universal_binary if build.universal?
+
+    safe_phpize
+    system "./configure", "--prefix=#{prefix}", phpconfig
+    system "make"
+    prefix.install "modules/spx.so"
+    write_config_file if build.with? "config-file"
+  end
+end


### PR DESCRIPTION
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

Today I discovered this excellent new profiler (https://github.com/NoiseByNorthwest/php-spx) and this PR makes it simple for others to install it too!

Note that for php72-spx you need to run `brew install php72-spx --env=std` so that you don’t an error like
```
fatal error: 'main/php.h' file not found
#include "main/php.h"
         ^
1 error generated.
make: *** [src/php_spx.lo] Error 1
```


-----
A side-comment:
`brew audit --strict --online php72-spx`
```
homebrew/php/php72-spx:
  * C: 1: col 14: Use `expand_path('../Abstract/abstract-php-extension', __dir__)` instead of `expand_path('../../Abstract/abstract-php-extension', __FILE__)`.
  * Stable: version 0.2.2 is redundant with version scanned from URL
Error: 2 problems in 1 formula
```

I copy and paste the `expand_path('../Abstract/abstract-php-extension', __dir__)` part and run it again:
`brew audit --strict --online php72-spx`
```
homebrew/php/php72-spx:
  * C: 1: col 26: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
Error: 1 problem in 1 formula
```

Is it possible to change the hint to `expand_path("../Abstract/abstract-php-extension", __dir__)` or is that third party code?