### PR TITLE
tap_migrations: remove migrations to homebrew/boneyard

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,8 +1,6 @@
 {
   "composer": "homebrew/core",
   "php-cs-fixer": "homebrew/core",
-  "phpenv": "homebrew/boneyard",
-  "phpsh": "homebrew/boneyard",
   "php72": "homebrew/core",
   "wp-cli": "homebrew/core"
 }


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

The boneyard has no formulae now so no migrations should point there
anymore.